### PR TITLE
add docker compose with db to devcontainer setup

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,10 +2,9 @@
 // README at: https://github.com/devcontainers/templates/tree/main/src/python
 {
   "name": "${localWorkspaceFolderBasename}",
-  "build": {
-    "dockerfile": "Dockerfile",
-    "args": {}
-  },
+  "dockerComposeFile": "./docker-compose.yml",
+  "service": "asqi",
+  "workspaceFolder": "/workspaces/asqi",
   "features": {
     "ghcr.io/devcontainers/features/docker-in-docker:2": {},
     "ghcr.io/anthropics/devcontainer-features/claude-code:1.0": {}
@@ -38,5 +37,11 @@
   // Mount dotfiles
   "mounts": [
     "source=${localEnv:HOME}/.aliases,target=/home/vscode/.bash_aliases,type=bind,consistency=cached"
-  ]
+  ],
+  "forwardPorts": [5432],
+  "portsAttributes": {
+    "5432": {
+      "label": "PostgreSQL"
+    }
+  }
 }

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,30 @@
+version: '3.9'
+
+services:
+  db:
+    image: pgvector/pgvector:pg16
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: dbos
+      POSTGRES_DB: dbos_app_starter
+    ports:
+      - "5432:5432"
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+
+  asqi:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    depends_on:
+      - db
+    environment:
+      DBOS_DATABASE_URL: postgres://postgres:dbos@db:5432/dbos_app_starter
+    restart: unless-stopped
+    volumes:
+      # Mount the workspace
+      - ..:/workspaces/asqi:cached
+    command: sleep infinity
+
+volumes:
+  pgdata:


### PR DESCRIPTION
Note that the postgres db is on the main host, not on docker-on-docker. This setup simplifies development since it includes all the infra that is needed to run the workflow executor.