### PR TITLE
update sut config to params

### DIFF
--- a/config/suts/demo_suts.yaml
+++ b/config/suts/demo_suts.yaml
@@ -1,7 +1,7 @@
 systems_under_test:
   openai_gpt4o_mini:
     type: "llm_api"
-    config:
+    params:
       base_url: "http://localhost:4000/v1"
       model: "gpt-4o-mini" # Uses litellm configured model
       api_key: "sk-1234" # API key configured in litellm proxy
@@ -9,21 +9,20 @@ systems_under_test:
   # Direct OpenAI API access with explicit API key
   direct_openai:
     type: "llm_api"
-    config:
+    params:
       base_url: "https://api.openai.com/v1"
       model: "gpt-4o-mini"
       api_key: "sk-your-openai-key-here"
 
-  # LiteLLM proxy with custom env file
+  # LiteLLM proxy using fallback values from .env file
   my_llm_service:
     type: "llm_api"
-    config:
-      base_url: "http://localhost:4000/v1"
+    params:
       model: "my-model"
-      env_file: ".env"  # Custom env file path
+      # No base_url or api_key specified - will use fallbacks from .env
 
   # This SUT is *not* compatible, for demonstrating validation failure
   my_backend_api:
     type: "rest_api"
-    config:
+    params:
       uri: "https://api.example.com/v1/data"

--- a/src/asqi/schemas.py
+++ b/src/asqi/schemas.py
@@ -95,9 +95,9 @@ class SUTDefinition(BaseModel):
         ...,
         description="e.g., 'llm_api', 'rest_api'. Used to match with test container capabilities.",
     )
-    config: Dict[str, Any] = Field(
+    params: Dict[str, Any] = Field(
         ...,
-        description="Configuration specific to the SUT type (e.g., base_url, model name, API key).",
+        description="Parameters specific to the SUT type (e.g., base_url, model name, API key).",
     )
 
 

--- a/src/asqi/validation.py
+++ b/src/asqi/validation.py
@@ -162,7 +162,7 @@ def create_test_execution_plan(
                     "test_name": test.name,
                     "image": image,
                     "sut_name": sut_name,
-                    "sut_config": {"type": sut_def.type, **sut_def.config},
+                    "sut_params": {"type": sut_def.type, **sut_def.params},
                     "test_params": getattr(test, "params", {}),
                 }
             )
@@ -299,7 +299,7 @@ def validate_test_execution_inputs(
     test_name: str,
     image: str,
     sut_name: str,
-    sut_config: Dict[str, Any],
+    sut_params: Dict[str, Any],
     test_params: Dict[str, Any],
 ) -> None:
     """
@@ -309,7 +309,7 @@ def validate_test_execution_inputs(
         test_name: Name of the test
         image: Docker image name
         sut_name: Name of the SUT
-        sut_config: SUT configuration dictionary
+        sut_params: SUT parameters dictionary (flattened configuration)
         test_params: Test parameters dictionary
 
     Raises:
@@ -324,8 +324,8 @@ def validate_test_execution_inputs(
     if not sut_name or not isinstance(sut_name, str):
         raise ValueError("Invalid SUT name: must be non-empty string")
 
-    if not isinstance(sut_config, dict):
-        raise ValueError("Invalid SUT configuration: must be dictionary")
+    if not isinstance(sut_params, dict):
+        raise ValueError("Invalid SUT parameters: must be dictionary")
 
     if not isinstance(test_params, dict):
         raise ValueError("Invalid test parameters: must be dictionary")

--- a/test_containers/mock_tester/entrypoint.py
+++ b/test_containers/mock_tester/entrypoint.py
@@ -9,7 +9,7 @@ def main():
     """Main entrypoint that demonstrates the container interface."""
     parser = argparse.ArgumentParser(description="Mock test container")
     parser.add_argument(
-        "--sut-config", required=True, help="SUT configuration as JSON string"
+        "--sut-params", required=True, help="SUT parameters as JSON string"
     )
     parser.add_argument(
         "--test-params", required=True, help="Test parameters as JSON string"
@@ -19,18 +19,17 @@ def main():
 
     try:
         # Parse inputs
-        sut_config = json.loads(args.sut_config)
+        sut_params = json.loads(args.sut_params)
         test_params = json.loads(args.test_params)
 
         # Validate SUT type
-        sut_type = sut_config.get("type")
+        sut_type = sut_params.get("type")
         if sut_type not in ["llm_api"]:
             raise ValueError(f"Unsupported SUT type: {sut_type}")
 
-        # Extract SUT configuration
-        config = sut_config.get("config", {})
-        base_url = config.get("base_url", "")
-        model = config.get("model", "")
+        # Extract SUT parameters (flattened structure)
+        base_url = sut_params["base_url"]  # Required, validated upstream
+        model = sut_params["model"]  # Required, validated upstream
 
         # Extract delay parameter
         delay_seconds = test_params.get("delay_seconds", 0)

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -31,7 +31,7 @@ systems_under_test:
   # This SUT is compatible with our mock_tester
   my_llm_service:
     type: "llm_api"
-    config:
+    params:
       provider: "some_provider"
       model: "model-x"
       api_key_env: "MY_LLM_API_KEY"
@@ -39,7 +39,7 @@ systems_under_test:
   # This SUT is *not* compatible, for demonstrating validation failure
   my_backend_api:
     type: "rest_api"
-    config:
+    params:
       uri: "https://api.example.com/v1/data"
 """
 
@@ -124,12 +124,12 @@ class TestSchemaValidation:
         # Check LLM service
         llm_sut = suts["my_llm_service"]
         assert llm_sut.type == "llm_api"
-        assert llm_sut.config["provider"] == "some_provider"
+        assert llm_sut.params["provider"] == "some_provider"
 
         # Check backend API
         api_sut = suts["my_backend_api"]
         assert api_sut.type == "rest_api"
-        assert api_sut.config["uri"] == "https://api.example.com/v1/data"
+        assert api_sut.params["uri"] == "https://api.example.com/v1/data"
 
     def test_manifest_schema_validation(self, manifests):
         """Test that manifests parse correctly."""

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -62,7 +62,7 @@ def test_run_test_suite_workflow_success():
 
     suts_config = {
         "systems_under_test": {
-            "sutA": {"type": "llm_api", "config": {"endpoint": "http://x"}}
+            "sutA": {"type": "llm_api", "params": {"endpoint": "http://x"}}
         }
     }
 
@@ -100,7 +100,7 @@ def test_run_test_suite_workflow_success():
                 "test_name": "t1_sutA",
                 "image": "test/image:latest",
                 "sut_name": "sutA",
-                "sut_config": {"type": "llm_api", "endpoint": "http://x"},
+                "sut_params": {"type": "llm_api", "endpoint": "http://x"},
                 "test_params": {"p": "v"},
             }
         ]
@@ -133,7 +133,7 @@ def test_run_test_suite_workflow_validation_failure():
         ],
     }
 
-    suts_config = {"systems_under_test": {"sutA": {"type": "llm_api", "config": {}}}}
+    suts_config = {"systems_under_test": {"sutA": {"type": "llm_api", "params": {}}}}
 
     with (
         patch("asqi.workflow.check_image_availability") as mock_avail,
@@ -171,7 +171,7 @@ def test_execute_single_test_success():
             test_name="t1_sutA",
             image="test/image:latest",
             sut_name="sutA",
-            sut_config={"type": "llm_api"},
+            sut_params={"type": "llm_api"},
             test_params={"p": "v"},
         )
 
@@ -208,7 +208,7 @@ def test_execute_single_test_container_failure():
             test_name="failing_test",
             image="test/image:latest",
             sut_name="sutA",
-            sut_config={"type": "llm_api"},
+            sut_params={"type": "llm_api"},
             test_params={},
         )
 
@@ -233,7 +233,7 @@ def test_execute_single_test_invalid_json():
             test_name="json_test",
             image="test/image:latest",
             sut_name="sutA",
-            sut_config={"type": "llm_api"},
+            sut_params={"type": "llm_api"},
             test_params={},
         )
 


### PR DESCRIPTION
Rename `sut-config` to `sut-params`, `sut_config` to `sut_params` and the field itself `config` to `params`. This aligns better with `test-params` and reduces confusion. 

Also, use `BASE_URL` and `API_KEY` as configured in a `.env` file as global fallbacks that will be passed as `sut-params` to the respective test containers.