### PR TITLE
remove image name from manifest

### DIFF
--- a/src/asqi/main.py
+++ b/src/asqi/main.py
@@ -103,10 +103,16 @@ def load_and_validate_plan(
                 continue
 
             manifest = Manifest(**manifest_data)
-            if manifest.image_name in manifests:
-                # If two manifests have the same image_name, we currently just overwrite and keep the last one.
+
+            # Use directory name to derive image name for local validation
+            # e.g., "test_containers/mock_tester/manifest.yaml" -> "mock_tester"
+            container_dir = os.path.basename(os.path.dirname(manifest_path))
+
+            # Check for duplicate container directories
+            if container_dir in manifests:
+                # If two manifests have the same container directory, we currently just overwrite and keep the last one.
                 pass
-            manifests[manifest.image_name] = manifest
+            manifests[container_dir] = manifest
 
     except (FileNotFoundError, ValueError, ValidationError, PermissionError) as e:
         errors.append(str(e))

--- a/src/asqi/schemas.py
+++ b/src/asqi/schemas.py
@@ -48,7 +48,6 @@ class Manifest(BaseModel):
     name: str = Field(..., description="The canonical name for the test framework.")
     version: str
     description: Optional[str] = None
-    image_name: str = Field(..., description="The full Docker image name and tag.")
     supported_suts: List[SUTSupport] = Field(
         ..., description="Declares which SUT types this framework can handle."
     )

--- a/test_containers/garak/manifest.yaml
+++ b/test_containers/garak/manifest.yaml
@@ -1,7 +1,6 @@
 name: "garak"
 version: "1.0"
 description: "Garak LLM security testing framework container for vulnerability assessment."
-image_name: "my-registry/garak:latest"
 
 supported_suts:
   - type: "llm_api"

--- a/test_containers/mock_tester/manifest.yaml
+++ b/test_containers/mock_tester/manifest.yaml
@@ -1,7 +1,6 @@
 name: "mock_tester"
 version: "1.0"
 description: "A lightweight mock container for testing the executor logic."
-image_name: "my-registry/mock_tester:latest"
 
 supported_suts:
   - type: "llm_api"

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -47,7 +47,6 @@ MOCK_TESTER_MANIFEST = {
     "name": "mock_tester",
     "version": "1.0.0",
     "description": "A minimal mock container for testing the executor interface.",
-    "image_name": "my-registry/mock_tester:latest",
     "supported_suts": [{"type": "llm_api"}],
     "input_schema": [
         {
@@ -64,7 +63,6 @@ MOCK_MULTIPLE_MANIFEST = {
     "name": "garak",
     "version": "0.2.0",
     "description": "A security and safety probing tool for Large Language Models.",
-    "image_name": "my-registry/garak:latest",
     "supported_suts": [{"type": "llm_api"}, {"type": "rest_api"}],
     "input_schema": [
         {

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -71,7 +71,6 @@ def test_run_test_suite_workflow_success():
         name="mock",
         version="1",
         description="",
-        image_name="test/image:latest",
         supported_suts=[SUTSupport(type="llm_api", required_config=None)],
         input_schema=[],
         output_metrics=[],


### PR DESCRIPTION
It's redundant since the image name should just be what was built. For local validation, we just use the directory structure for now.