### PR TITLE
Use host network by default

### DIFF
--- a/config/suts/demo_suts.yaml
+++ b/config/suts/demo_suts.yaml
@@ -2,7 +2,7 @@ systems_under_test:
   openai_gpt4o_mini:
     type: "llm_api"
     params:
-      base_url: "http://litellm:4000/v1" # Use docker service name, change to localhost if on host machine
+      base_url: "http://localhost:4000/v1" # Use litellm on port 4000
       model: "openai/gpt-4o-mini" # Uses litellm configured model
       api_key: "sk-1234" # API key configured in litellm proxy
 

--- a/src/asqi/container_manager.py
+++ b/src/asqi/container_manager.py
@@ -219,6 +219,7 @@ def run_container_with_args(
     cpu_period: int = 100000,
     environment: Optional[Dict[str, str]] = None,
     stream_logs: bool = False,
+    network: str = "host",
 ) -> Dict[str, Any]:
     """
     Run a Docker container with specified arguments and return results.
@@ -232,6 +233,7 @@ def run_container_with_args(
         cpu_period: CPU period for container
         environment: Optional dictionary of environment variables to pass to container
         stream_logs: If True, stream logs in real-time
+        network: Docker network mode (default: "host")
 
     Returns:
         Dictionary with execution results including exit_code, output, success, etc.
@@ -249,13 +251,15 @@ def run_container_with_args(
         container = None
         try:
             # Run container
-            logger.info(f"Running container for image '{image}' with args: {args}")
+            logger.info(
+                f"Running container for image '{image}' with args: {args} on network: {network}"
+            )
             container = client.containers.run(
                 image,
                 command=args,
                 detach=True,
                 remove=False,
-                network_mode="bridge",
+                network_mode=network,
                 mem_limit=memory_limit,
                 cpu_period=cpu_period,
                 cpu_quota=cpu_quota,


### PR DESCRIPTION
It's easier to run the test containers with access to host for networking accessibility reasons, especially for API services. We could consider adding more flexibility and allowing users to customise the parameters in the future.