### PR TITLE
increase default memory limit and cpu quota

### DIFF
--- a/src/asqi/config.py
+++ b/src/asqi/config.py
@@ -9,8 +9,8 @@ class ContainerConfig:
     """Configuration constants for container execution."""
 
     TIMEOUT_SECONDS: int = 300
-    MEMORY_LIMIT: str = "512m"
-    CPU_QUOTA: int = 50000
+    MEMORY_LIMIT: str = "2g"
+    CPU_QUOTA: int = 200000
     CPU_PERIOD: int = 100000
     MANIFEST_PATH: str = "/app/manifest.yaml"
 


### PR DESCRIPTION
Some of the modules in the trustllm package uses a local model for evaluation. This requires more memory and CPU for the task. It might be nice to allow each container to more flexibility specify their resource required but in the mean time the new setting should work for all existing tests:

```py
MEMORY_LIMIT: str = "2g"
CPU_QUOTA: int = 200000
```