### PR TITLE
fix deepteam version and opt out of data collection

### DIFF
--- a/test_containers/deepteam/Dockerfile
+++ b/test_containers/deepteam/Dockerfile
@@ -13,11 +13,11 @@ RUN apt-get update && \
 ENV PATH="/root/.cargo/bin:${PATH}"
 
 # Install deepteam and its dependencies
-RUN pip install --no-cache-dir deepteam
-
+RUN pip install --no-cache-dir deepteam==0.2.4 litellm==1.76.0
 COPY manifest.yaml .
 COPY entrypoint.py .
 
+ENV DEEPTEAM_TELEMETRY_OPT_OUT="YES"
 RUN chmod +x entrypoint.py
 
 ENTRYPOINT ["python", "./entrypoint.py"]


### PR DESCRIPTION
Fixes #50 - the data collection was throwing an error within the container. Explicitly opting out by setting `ENV DEEPTEAM_TELEMETRY_OPT_OUT="YES"` fixes the problem.

I have also pinned the version of deepteam and litellm to prevent dependency issues if there are new versions with breaking changes.