### PR TITLE
Simplify container name used in logger

### DIFF
--- a/src/asqi/container_manager.py
+++ b/src/asqi/container_manager.py
@@ -428,7 +428,7 @@ def run_container_with_args(
             )
 
             with _active_lock:
-                _active_containers.add(container.id)
+                _active_containers.add(container.id)  # type: ignore
 
             result["container_id"] = container.id or ""
             output_lines = []


### PR DESCRIPTION
Reduce clutter by just showing the name instead including the registry and tags. Here's how it looks:
```
[03:28:29] [    INFO] [garak] Preparing prompts:   0%|          | 0/127 [00:00<?, ?it/s]
[03:28:29] [    INFO] [garak] Preparing prompts:   0%|          | 0/256 [00:00<?, ?it/s]
[03:28:31] [    INFO] [garak]   0%|          | 0/127 [00:00<?, ?it/s]
[03:28:31] [    INFO] [garak] probes.dan.Ablation_Dan_11_0:   0%|          | 0/127 [00:00<?, ?it/s]
```

vs existing

```
[03:19:56] [    INFO] [my-registry/deepteam:latest] {
[03:19:56] [    INFO] [my-registry/deepteam:latest]   "success": false,
[03:19:56] [    INFO] [my-registry/deepteam:latest]   "error": "Invalid vulnerability names: ['bflas']. Valid vulnerabilities are: ['bfla', 'bias', 'bola', 'competition', 'debug_access', 'excessive_agency', 'goal_theft', 'graphic_content', 'illegal_activity', 
```