### PR TITLE
Plt 107 support yaml options that apply across all test suites 36

### DIFF
--- a/src/asqi/config.py
+++ b/src/asqi/config.py
@@ -50,7 +50,7 @@ def merge_defaults_into_suite(config: Dict[str, Any]) -> Dict[str, Any]:
         Config with defaults merged into `test_suite`
     """
     if "test_suite_default" not in config:
-        return config  # nothing to do
+        return config
 
     default = config["test_suite_default"]
 
@@ -63,7 +63,6 @@ def merge_defaults_into_suite(config: Dict[str, Any]) -> Dict[str, Any]:
                 merged[k] = v
         return merged
 
-    # Apply defaults to each test
     new_suite = []
     for test in config["test_suite"]:
         merged_test = deep_merge(default, test)
@@ -71,20 +70,6 @@ def merge_defaults_into_suite(config: Dict[str, Any]) -> Dict[str, Any]:
 
     config["test_suite"] = new_suite
     return config
-
-
-def load_suite_config_file(file_path: str) -> Dict[str, Any]:
-    """
-    Load suite config file with support for `test_suite_default`.
-
-    Args:
-        file_path: Path to YAML file
-
-    Returns:
-        Final merged config dictionary
-    """
-    config = load_config_file(file_path)
-    return merge_defaults_into_suite(config)
 
 
 def save_results_to_file(results: Dict[str, Any], output_path: str) -> None:

--- a/src/asqi/workflow.py
+++ b/src/asqi/workflow.py
@@ -13,7 +13,7 @@ from asqi.config import (
     ContainerConfig,
     ExecutorConfig,
     load_config_file,
-    load_suite_config_file,
+    merge_defaults_into_suite,
     save_results_to_file,
 )
 from asqi.container_manager import (
@@ -757,10 +757,8 @@ def start_test_execution(
 
     try:
         # Load configurations
-        suite_config = load_suite_config_file(suite_path)
+        suite_config = merge_defaults_into_suite(load_config_file(suite_path))
         suts_config = load_config_file(suts_path)
-
-        console.print(f"suite_config: {suite_config}")
 
         # Start appropriate workflow based on execution mode
         if execution_mode == "tests_only":


### PR DESCRIPTION
### Changes

* Added `merge_defaults_into_suite` in `config.py`:

  * Recursively merges `test_suite_default` values into each `test_suite` entry.
  * Per-test overrides take precedence.
  * Nested dictionaries (e.g. `params`) are deep-merged.

* Added unit tests in `test_config.py` to cover:

  * Default inheritance across multiple tests.
  * Overriding individual keys in tests.
  * Configs without `test_suite_default` (no changes applied).
  * Handling of nested dictionaries.

Addresses feature request in #36 

Example demo_suite.yaml 

```yaml
suite_name: "Mock Tester Sanity Check"
test_suite_default:
    image: "my-registry/mock_tester:latest"
    target_suts:
      - "my_llm_service"
    params:
      delay_seconds: 1
test_suite:
  - name: "test1"
  - name: "test2"
    params:
      delay_seconds: 2
  - name: "test3"
    target_suts:
      - "my_llm_service"
```