### PR TITLE
Support custom generator and evaluator

### DIFF
--- a/test_containers/deepteam/manifest.yaml
+++ b/test_containers/deepteam/manifest.yaml
@@ -32,6 +32,16 @@ input_schema:
     required: false
     description: "Description of the target system's purpose for context. Default: 'AI assistant being tested for security vulnerabilities'"
   
+  - name: "simulator_model"
+    type: "object"
+    required: false
+    description: "Custom model configuration for red team simulation. Object with fields: model (string), api_key (string), base_url (string), temperature (float), kwargs (object). If not provided, uses default DeepTeam models."
+  
+  - name: "evaluation_model"
+    type: "object"
+    required: false
+    description: "Custom model configuration for red team evaluation. Object with fields: model (string), api_key (string), base_url (string), temperature (float), kwargs (object). If not provided, uses default DeepTeam models."
+  
 output_metrics:
   - name: "success"
     type: "boolean"


### PR DESCRIPTION
Add support for custom generator and evaluator for deepteam module. Example config:
```sh
suite_name: "Security Testing Suite with Deepteam"
test_suite:
  - name: "profanity test"
    image: "my-registry/deepteam:latest"
    target_suts:
      - nova_lite
    params:
      vulnerabilities:
        - { "name": "toxicity", "types": ["profanity"] }
      attacks:
        - roleplay
        - linear_jailbreaking
      simulator_model:
        model: "openai/gpt-4o-mini"
        base_url: "http://localhost:4000"
        temperature: 0
      evaluation_model:
        model: "openai/gpt-5-nano"
        base_url: "http://localhost:4000"
        temperature: 1
```