### PR TITLE
Patch test containers to support simulator and evaluator systems

### DIFF
--- a/test_containers/chatbot_simulator/manifest.yaml
+++ b/test_containers/chatbot_simulator/manifest.yaml
@@ -45,14 +45,6 @@ input_schema:
     type: "integer"
     required: false
     description: "Number of simulation runs per scenario-persona combination (default: 1)"
-  - name: "simulator_model"
-    type: "string"
-    required: false
-    description: "Model to use for persona simulation (default: gpt-4o-mini)"
-  - name: "evaluation_model"
-    type: "string"
-    required: false
-    description: "Model to use for LLM-as-judge evaluation (default: gpt-4o-mini)"
   - name: "success_threshold"
     type: "float"
     required: false

--- a/test_containers/deepteam/entrypoint.py
+++ b/test_containers/deepteam/entrypoint.py
@@ -215,7 +215,7 @@ class DeepTeamRedTeamTester:
             return None
 
         # Use the API key from the system config, or fallback to environment
-        api_key = system_config.get("api_key") or os.environ.get("API_KEY", "sk-1234")
+        api_key = system_config.get("api_key") or os.environ.get("API_KEY", "")
 
         return CustomOpenAIModel(
             model=system_config.get("model", "gpt-4o-mini"),


### PR DESCRIPTION
Part 3 of #75 and a continuation of #79, this PR removes the previous `simulator_model` and `evaluation_model` in `deepteam` and `chatbot_simulator` test packages and uses the newly introduced `simulator_system` and `evaluator_system` fields instead.