### PR TITLE
Dynamic project version

### DIFF
--- a/.github/workflows/asqi-cd.yaml
+++ b/.github/workflows/asqi-cd.yaml
@@ -57,7 +57,7 @@ jobs:
 
       - name: 🛠️ Install build dependencies
         run: |
-          uv sync --python ${{ matrix.python-version }} --group dev
+          uv sync --locked --python ${{ matrix.python-version }} --group dev
 
       - name: 🔨 Build package
         run: uv build --wheel

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          uv sync --dev
+          uv sync --locked --dev
 
       - name: Build documentation
         run: |

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -21,7 +21,7 @@ jobs:
           
       - name: Install dependencies
         run: |
-          uv sync --group dev
+          uv sync --locked --group dev
           
       - name: Run ruff (lint)
         run: uv run ruff check .

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -23,7 +23,7 @@ jobs:
           
       - name: Install dependencies
         run: |
-          uv sync --group dev
+          uv sync --locked --group dev
           
       - name: Run bandit
         run: uv run bandit -r . --configfile pyproject.toml

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -25,7 +25,7 @@ jobs:
           
       - name: Install dependencies
         run: |
-          uv sync --python ${{ matrix.python-version }} --group dev
+          uv sync --locked --python ${{ matrix.python-version }} --group dev
           
       - name: Run tests
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ exclude_dirs = [".venv", "tests", "test_containers/mock_tester"]
 skips = ["B404", "B603"]
 
 [build-system]
-requires = ["hatchling", "pydantic>=2.11.7"]
+requires = ["hatchling", "hatch-vcs", "pydantic>=2.11.7"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]

--- a/uv.lock
+++ b/uv.lock
@@ -145,7 +145,6 @@ wheels = [
 
 [[package]]
 name = "asqi-engineer"
-version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "dbos" },


### PR DESCRIPTION
Set from tag.
Valid tags are defined in [pep 440](https://peps.python.org/pep-0440/).

For example:
v1.0.0a1: The first alpha release of version 1.0.0.
v1.0.0a2: The second alpha release.

v1.0.0b1: The first beta release of version 1.0.0.
v1.0.0b2: The second beta release.

v1.0.0rc1: The first release candidate for version 1.0.0.
v1.0.0rc2: The second release candidate.

v1.0.0 : final release