### PR TITLE
Add test suite default typing to schema

### DIFF
--- a/config/docker_container.yaml
+++ b/config/docker_container.yaml
@@ -1,8 +1,7 @@
-
 # this is configuration for docker containers
 
-timeout_seconds : 300 # Container execution timeout in seconds
-stream_logs : true # Whether to stream container logs in real-time
+timeout_seconds: 300 # Container execution timeout in seconds
+stream_logs: true # Whether to stream container logs in real-time
 
 cleanup_on_finish: true # Whether to force-remove containers on shutdown
 cleanup_force: true # Whether to force-remove containers during cleanup

--- a/src/asqi/main.py
+++ b/src/asqi/main.py
@@ -9,7 +9,7 @@ import yaml
 from pydantic import ValidationError
 from rich.console import Console
 
-from asqi.config import ContainerConfig, ExecutorConfig
+from asqi.config import ContainerConfig, ExecutorConfig, merge_defaults_into_suite
 from asqi.container_manager import shutdown_containers
 from asqi.logging_config import configure_logging
 from asqi.schemas import Manifest, ScoreCard, SuiteConfig, SystemsConfig
@@ -90,6 +90,7 @@ def load_and_validate_plan(
         systems_config = SystemsConfig(**systems_data)
 
         suite_data = load_yaml_file(suite_path)
+        suite_data = merge_defaults_into_suite(suite_data)
         suite_config = SuiteConfig(**suite_data)
 
         # Load manifests - currently just loads locally. TODO: obtain from registry

--- a/src/asqi/schemas.py
+++ b/src/asqi/schemas.py
@@ -120,7 +120,29 @@ class SystemsConfig(BaseModel):
 # ----------------------------------------------------------------------------
 
 
-class TestDefinition(BaseModel):
+class TestDefinitionBase(BaseModel):
+    """Base class for test configuration fields shared between TestDefinition and TestSuiteDefault."""
+
+    systems_under_test: Optional[List[str]] = Field(
+        None,
+        description="A list of system names (from systems.yaml) to run this test against. Can be inherited from test_suite_default.",
+    )
+    systems: Optional[Dict[str, str]] = Field(
+        None,
+        description="Optional additional systems for the test (e.g., simulator_system, evaluator_system).",
+    )
+    tags: Optional[List[str]] = Field(
+        None, description="Optional tags for filtering and reporting."
+    )
+    params: Optional[Dict[str, Any]] = Field(
+        None, description="Parameters to be passed to the test container's entrypoint."
+    )
+    volumes: Optional[Dict[str, Any]] = Field(
+        None, description="Optional input/output mounts."
+    )
+
+
+class TestDefinition(TestDefinitionBase):
     """A single test to be executed."""
 
     name: str = Field(
@@ -130,29 +152,22 @@ class TestDefinition(BaseModel):
         ...,
         description="The Docker image to run for this test, e.g., 'my-registry/garak:latest'.",
     )
-    systems_under_test: List[str] = Field(
-        ...,
-        description="A list of system names (from systems.yaml) to run this test against.",
-    )
-    systems: Optional[Dict[str, str]] = Field(
-        None,
-        description="Optional additional systems for the test (e.g., simulator_system, evaluator_system).",
-    )
-    tags: Optional[List[str]] = Field(
-        None, description="Optional tags for filtering and reporting."
-    )
-    params: Dict[str, Any] = Field(
-        {}, description="Parameters to be passed to the test container's entrypoint."
-    )
-    volumes: Optional[Dict[str, Any]] = Field(
-        {}, description="Optional input/output mounts."
-    )
+
+
+class TestSuiteDefault(TestDefinitionBase):
+    """Default values that apply to all tests in the suite unless overridden."""
+
+    pass
 
 
 class SuiteConfig(BaseModel):
     """Schema for the top-level Test Suite configuration file."""
 
     suite_name: str
+    test_suite_default: Optional[TestSuiteDefault] = Field(
+        None,
+        description="Default values that apply to all tests in the suite unless overridden",
+    )
     test_suite: List[TestDefinition]
 
 

--- a/src/asqi/schemas/asqi_suite_config.schema.json
+++ b/src/asqi/schemas/asqi_suite_config.schema.json
@@ -3,23 +3,21 @@
     "TestDefinition": {
       "description": "A single test to be executed.",
       "properties": {
-        "name": {
-          "description": "A unique, human-readable name for this test instance.",
-          "title": "Name",
-          "type": "string"
-        },
-        "image": {
-          "description": "The Docker image to run for this test, e.g., 'my-registry/garak:latest'.",
-          "title": "Image",
-          "type": "string"
-        },
         "systems_under_test": {
-          "description": "A list of system names (from systems.yaml) to run this test against.",
-          "items": {
-            "type": "string"
-          },
-          "title": "Systems Under Test",
-          "type": "array"
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "A list of system names (from systems.yaml) to run this test against. Can be inherited from test_suite_default.",
+          "title": "Systems Under Test"
         },
         "systems": {
           "anyOf": [
@@ -54,11 +52,18 @@
           "title": "Tags"
         },
         "params": {
-          "additionalProperties": true,
-          "default": {},
+          "anyOf": [
+            {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
           "description": "Parameters to be passed to the test container's entrypoint.",
-          "title": "Params",
-          "type": "object"
+          "title": "Params"
         },
         "volumes": {
           "anyOf": [
@@ -70,17 +75,109 @@
               "type": "null"
             }
           ],
-          "default": {},
+          "default": null,
           "description": "Optional input/output mounts.",
           "title": "Volumes"
+        },
+        "name": {
+          "description": "A unique, human-readable name for this test instance.",
+          "title": "Name",
+          "type": "string"
+        },
+        "image": {
+          "description": "The Docker image to run for this test, e.g., 'my-registry/garak:latest'.",
+          "title": "Image",
+          "type": "string"
         }
       },
       "required": [
         "name",
-        "image",
-        "systems_under_test"
+        "image"
       ],
       "title": "TestDefinition",
+      "type": "object"
+    },
+    "TestSuiteDefault": {
+      "description": "Default values that apply to all tests in the suite unless overridden.",
+      "properties": {
+        "systems_under_test": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "A list of system names (from systems.yaml) to run this test against. Can be inherited from test_suite_default.",
+          "title": "Systems Under Test"
+        },
+        "systems": {
+          "anyOf": [
+            {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Optional additional systems for the test (e.g., simulator_system, evaluator_system).",
+          "title": "Systems"
+        },
+        "tags": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Optional tags for filtering and reporting.",
+          "title": "Tags"
+        },
+        "params": {
+          "anyOf": [
+            {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Parameters to be passed to the test container's entrypoint.",
+          "title": "Params"
+        },
+        "volumes": {
+          "anyOf": [
+            {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Optional input/output mounts.",
+          "title": "Volumes"
+        }
+      },
+      "title": "TestSuiteDefault",
       "type": "object"
     }
   },
@@ -89,6 +186,18 @@
     "suite_name": {
       "title": "Suite Name",
       "type": "string"
+    },
+    "test_suite_default": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/TestSuiteDefault"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Default values that apply to all tests in the suite unless overridden"
     },
     "test_suite": {
       "items": {


### PR DESCRIPTION
Main changes:
- Add test suite default typing to schema
- Merge defaults before validating 

Make some of the fields e.g. `systems_under_test` optional as I don't think there's a simple approach to support the conditional typing introduced by having the `test_suite_default` field. So we can't do strict validation on the IDE but type hints which I think is a resonable compromise.

Fix #97 