### PR TITLE
Save Garak logs to output volume

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,7 @@ output.json
 
 # Docs
 docs/_build
+
+# Volumes
+input
+output

--- a/README.md
+++ b/README.md
@@ -298,6 +298,35 @@ input_systems:
 output_metrics: ["success", "score"]
 ```
 
+### Log Storage to Volumes
+
+Test containers can save detailed logs to mounted volumes for later analysis:
+
+**Chatbot Simulator**:
+- Saves detailed conversation logs via `conversation_log_filename` parameter (default: `conversation_logs.json`)
+- Contains full conversation transcripts, evaluation details, and persona information
+
+**Garak Security Tester**:
+- Saves full garak report via `garak_log_filename` parameter (default: `garak_output.jsonl`)
+- Contains detailed probe results, vulnerability assessments, and raw garak output in JSON Lines format
+
+**Example Usage**:
+```yaml
+test_suite:
+  - name: "chatbot_test"
+    image: "my-registry/chatbot_simulator:latest"
+    volumes:
+      output: /path/to/logs  # Mount host directory for log storage
+    params:
+      conversation_log_filename: "my_test_conversations.json"
+  - name: "security_test"
+    image: "my-registry/garak:latest"
+    volumes:
+      output: /path/to/logs  # Mount host directory for log storage
+    params:
+      garak_log_filename: "security_report.jsonl"
+```
+
 ## Building and Distribution
 
 ASQI can be packaged and distributed as a Python wheel for easy installation and sharing.

--- a/config/suites/chatbot_simulator_test.yaml
+++ b/config/suites/chatbot_simulator_test.yaml
@@ -8,6 +8,8 @@ test_suite:
     systems:
       simulator_system: openai_gpt4o_mini
       evaluator_system: nova_lite
+    volumes:
+      output: /workspaces/asqi/output # Add a output volume to save the log file
     params:
       chatbot_purpose: "Tesla customer service helping with vehicle info and services"
       custom_personas:
@@ -18,3 +20,4 @@ test_suite:
       simulations_per_scenario: 1
       max_concurrent: 4
       max_turns: 3
+      conversation_log_filename: conversation_logs.json

--- a/config/suites/garak_test.yaml
+++ b/config/suites/garak_test.yaml
@@ -6,15 +6,21 @@ test_suite:
     image: "asqiengineer/test-container:garak-latest"
     systems_under_test:
       - "openai_gpt4o_mini"
+    volumes:
+      output: /workspaces/asqi/output # Add a output volume to save the log file
     params:
       probes: ["encoding.InjectHex"]
       generations: 1
+      garak_log_filename: garak_output_encoding.jsonl
 
   # Prompt injection attacks testing
   - name: "garak_prompt_injection"
     image: "asqiengineer/test-container:garak-latest"
     systems_under_test:
       - "openai_gpt4o_mini"
+    volumes:
+      output: /workspaces/asqi/output
     params:
       probes: ["dan"]
       generations: 1
+      garak_log_filename: garak_output_dan.jsonl

--- a/src/asqi/container_manager.py
+++ b/src/asqi/container_manager.py
@@ -477,7 +477,7 @@ def run_container_with_args(
                 if output_lines:
                     result["output"] = "\n".join(output_lines)
                 else:
-                    logger.error(f"container.logs() : {container.logs()}")
+                    logger.debug(f"container.logs() : {container.logs()}")
                     result["output"] = container.logs().decode(
                         "utf-8", errors="replace"
                     )

--- a/src/asqi/workflow.py
+++ b/src/asqi/workflow.py
@@ -236,7 +236,9 @@ def execute_single_test(
         if os.path.exists(env_file_path):
             try:
                 env_vars = dotenv_values(env_file_path)
-                container_env.update(env_vars)
+                # Filter out None values to ensure all env vars are strings
+                filtered_env_vars = {k: v for k, v in env_vars.items() if v is not None}
+                container_env.update(filtered_env_vars)
                 DBOS.logger.info(f"Loaded environment variables from {env_file_path}")
             except Exception as e:
                 DBOS.logger.warning(

--- a/test_containers/chatbot_simulator/entrypoint.py
+++ b/test_containers/chatbot_simulator/entrypoint.py
@@ -103,7 +103,13 @@ async def run_chatbot_simulation(
     print(f"Generated {len(test_cases)} conversation test cases")
 
     analyzer = ConversationTestAnalyzer(success_threshold=success_threshold)
-    analyzer.save_conversations(test_cases, conversation_log_filepath)
+    try:
+        analyzer.save_conversations(test_cases, conversation_log_filepath)
+    except (OSError, IOError, PermissionError) as e:
+        print(
+            f"Warning: Could not save conversation logs to {conversation_log_filepath}: {e}",
+            file=sys.stderr,
+        )
 
     analysis_json = analyzer.analyze_results(test_cases)
     print("\n🎉 Conversation testing complete!")

--- a/test_containers/chatbot_simulator/simulation.py
+++ b/test_containers/chatbot_simulator/simulation.py
@@ -337,8 +337,7 @@ Make the scenarios realistic and diverse, covering different use cases for this 
     ) -> ConversationalTestCase:
         """Simulate a single conversation"""
         print(
-            f"Simulating conversation {index + 1}/{total} - {user_data['scenario_id']}",
-            flush=True,
+            f"Simulating conversation {index + 1}/{total} - {user_data['scenario_id']}"
         )
 
         try:
@@ -377,7 +376,7 @@ Make the scenarios realistic and diverse, covering different use cases for this 
             }
 
         except Exception as e:
-            print(f"❌ Failed to simulate {user_data['scenario_id']}: {e}", flush=True)
+            print(f"❌ Failed to simulate {user_data['scenario_id']}: {e}")
             return {
                 "turns": [],
                 "evaluator_results": [],
@@ -398,7 +397,7 @@ Make the scenarios realistic and diverse, covering different use cases for this 
         self, scenarios: List[Dict[str, Any]]
     ) -> List[ConversationalTestCase]:
         """Run multiturn simulations using OpenEvals"""
-        print("Running multiturn simulations...", flush=True)
+        print("Running multiturn simulations...")
         app = self.create_app()
         simulated_users = self.create_simulated_users(scenarios)
 

--- a/test_containers/garak/entrypoint.py
+++ b/test_containers/garak/entrypoint.py
@@ -202,11 +202,10 @@ def main():
                         eval_entries = []
                         _run_info = None
 
-                        # Copy the full garak report to output volume if OUTPUT_MOUNT_PATH is available
-                        if "OUTPUT_MOUNT_PATH" in os.environ:
-                            output_mount_path = Path(os.environ["OUTPUT_MOUNT_PATH"])
-                            garak_output_path = output_mount_path / garak_log_filename
-
+                        # Copy the full garak report to output volume
+                        output_mount_path = Path(os.environ["OUTPUT_MOUNT_PATH"])
+                        garak_output_path = output_mount_path / garak_log_filename
+                        try:
                             # Copy the report file content to the mounted volume
                             with (
                                 open(report_file, "r") as src,
@@ -215,6 +214,11 @@ def main():
                                 dst.write(src.read())
                             print(
                                 f"Garak report saved to: {garak_output_path}",
+                                file=sys.stderr,
+                            )
+                        except (OSError, IOError, PermissionError) as e:
+                            print(
+                                f"Warning: Could not save garak report to {garak_output_path}: {e}",
                                 file=sys.stderr,
                             )
 

--- a/test_containers/garak/manifest.yaml
+++ b/test_containers/garak/manifest.yaml
@@ -21,6 +21,10 @@ input_schema:
     type: "integer"
     required: false
     description: "How many probe attempts to launch in parallel. Defaults to 8."
+  - name: "garak_log_filename"
+    type: "string"
+    required: false
+    description: "Filename for saving the full garak report to mounted volume (default: garak_output.jsonl)"
 
 output_metrics:
   - name: "success"


### PR DESCRIPTION
Main changes:
- Graceful writing of logs for both chatbot_simulator and garak
- Document usage of volumes in config examples and readme
- Save Garak logs to output volume