### PR TITLE
Use tag pattern to ignore container tags

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ path = "scripts/build_hooks.py"
 
 [tool.hatch.version]
 source = "vcs"
+tag-pattern = "v(?P<version>[0-9.]+)$"
 
 [tool.uv]
 package = true


### PR DESCRIPTION
Use tag pattern to separate python project tags from container tags