### PR TITLE
Revert "Use tag pattern to ignore container tags"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,6 @@ path = "scripts/build_hooks.py"
 
 [tool.hatch.version]
 source = "vcs"
-tag-pattern = "v(?P<version>[0-9.]+)$"
 
 [tool.uv]
 package = true


### PR DESCRIPTION
This reverts commit 7a53f71ee55e71ac815e1e69ccc4a403d6629486.