### PR TITLE
Load dotenv at main entrypoint

### DIFF
--- a/src/asqi/main.py
+++ b/src/asqi/main.py
@@ -6,6 +6,7 @@ from typing import Any, Dict, List, Optional
 
 import typer
 import yaml
+from dotenv import load_dotenv
 from pydantic import ValidationError
 from rich.console import Console
 
@@ -20,6 +21,7 @@ from asqi.logging_config import configure_logging
 from asqi.schemas import Manifest, ScoreCard, SuiteConfig, SystemsConfig
 from asqi.validation import validate_test_plan
 
+load_dotenv()
 configure_logging()
 console = Console()
 


### PR DESCRIPTION
Fix #148 - since workflow.py is lazy loaded, we can just `load_dotenv` in main.py to initialise the  `DBOS_DATABASE_URL` environment variable