### PR TITLE
Update image availability with newly pulled images

### DIFF
--- a/src/asqi/workflow.py
+++ b/src/asqi/workflow.py
@@ -474,6 +474,13 @@ def run_test_suite_workflow(
 
     # Extract manifests from available images (post-pull)
     manifests = {}
+
+    # After pulling, we need to check availability again to include newly pulled images
+    if missing_images:
+        updated_image_availability = dbos_check_images_availability(unique_images)
+        image_availability.update(updated_image_availability)
+
+    # Now get all available images including ones that were just pulled
     available_images = [
         img for img, available in image_availability.items() if available
     ]


### PR DESCRIPTION
Fix #150 - after pulling missing images, manifests are not extracted from newly pulled images, causing validation to fail even though the images are now available. The solution is to check availability again to include newly pulled images.