### PR TITLE
Fix default naming of cli command output

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,11 @@ The `llm_api` system type uses OpenAI-compatible API interfaces. Through [LiteLL
 
 Get started with ASQI Engineer in 3 simple steps:
 
+### Requirements
+
+- **Python 3.12+** is required
+- Docker for running test containers
+
 **1. Install the package:**
 
 ```bash

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,5 +1,10 @@
 # Quick Start
 
+### Requirements
+
+- **Python 3.12+** is required
+- Docker for running test containers
+
 ## Installation
 
 Get started with ASQI Engineer in 3 simple steps:

--- a/src/asqi/main.py
+++ b/src/asqi/main.py
@@ -225,7 +225,7 @@ def execute(
         ..., "--score-card-config", "-r", help="Path to grading score card YAML file."
     ),
     output_file: Optional[str] = typer.Option(
-        "output.json",
+        "output_scorecard.json",
         "--output-file",
         "-o",
         help="Path to save execution results JSON file.",
@@ -328,7 +328,7 @@ def execute_tests(
         ..., "--systems-config", "-s", help="Path to the systems YAML file."
     ),
     output_file: Optional[str] = typer.Option(
-        "output_scorecard.json",
+        "output.json",
         "--output-file",
         "-o",
         help="Path to save execution results JSON file.",


### PR DESCRIPTION
Fix #154. New default output files:
1. `execute` (with score cards): "output_scorecard.json"
2. `execute-tests` (no score cards): "output.json"
3. `evaluate-score-cards` (with score cards): "output_scorecard.json"