### PR TITLE
Create multi-platform build with manifest list

### DIFF
--- a/.github/workflows/asqi-container-publish.yaml
+++ b/.github/workflows/asqi-container-publish.yaml
@@ -52,14 +52,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Log into Docker Hub
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Build and push by digest
+      - name: Build platform image
         id: build
         uses: docker/build-push-action@v6
         with:
@@ -68,25 +61,17 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+          outputs: type=oci,dest=/tmp/image-${{ env.PLATFORM_PAIR }}.tar
 
-      - name: Export digest
-        run: |
-          mkdir -p ${{ runner.temp }}/digests
-          digest="${{ steps.build.outputs.digest }}"
-          touch "${{ runner.temp }}/digests/${digest#sha256:}"
-
-      - name: Upload digest
+      - name: Upload platform image
         uses: actions/upload-artifact@v4
         with:
-          name: digests-${{ env.PLATFORM_PAIR }}
-          path: ${{ runner.temp }}/digests/*
-          if-no-files-found: error
+          name: image-${{ env.PLATFORM_PAIR }}
+          path: /tmp/image-${{ env.PLATFORM_PAIR }}.tar
           retention-days: 1
 
   test:
     runs-on: self-hosted
-    needs: build
     permissions:
       contents: read
     steps:
@@ -117,7 +102,7 @@ jobs:
             exit 1
           fi
 
-  merge:
+  publish:
     if: github.event_name != 'pull_request'
     runs-on: self-hosted
     needs: [build, test]
@@ -132,11 +117,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v5
 
-      - name: Download digests
-        uses: actions/download-artifact@v5
+      - name: Download all platform images
+        uses: actions/download-artifact@v4
         with:
-          path: ${{ runner.temp }}/digests
-          pattern: digests-*
+          path: /tmp
+          pattern: image-*
           merge-multiple: true
 
       - name: Set up Docker Buildx
@@ -164,22 +149,31 @@ jobs:
             type=sha
             type=raw,value=latest,enable={{is_default_branch}}
 
-      - name: Create manifest list and push
-        working-directory: ${{ runner.temp }}/digests
+      - name: Import and push multi-platform images
+        id: push
         run: |
-          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@sha256:%s ' *)
+          # Import platform images
+          docker buildx imagetools create \
+            --dry-run \
+            $(echo '${{ steps.meta.outputs.tags }}' | tr '\n' ' ' | sed 's/^/-t /' | sed 's/ / -t /g') \
+            oci-archive:/tmp/image-linux-amd64.tar \
+            oci-archive:/tmp/image-linux-arm64.tar
+
+          # Actually push the images
+          docker buildx imagetools create \
+            $(echo '${{ steps.meta.outputs.tags }}' | tr '\n' ' ' | sed 's/^/-t /' | sed 's/ / -t /g') \
+            oci-archive:/tmp/image-linux-amd64.tar \
+            oci-archive:/tmp/image-linux-arm64.tar
+
+          # Get digest for attestation
+          if [[ $GITHUB_REF == refs/tags/* ]]; then
+            DIGEST=$(docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }} --format '{{.Manifest.Digest}}')
+            echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Inspect image
         run: |
           docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}
-
-      - name: Get manifest digest for attestation
-        id: manifest
-        if: startsWith(github.ref, 'refs/tags/')
-        run: |
-          DIGEST=$(docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }} --format '{{.Manifest.Digest}}')
-          echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
 
       - name: Attest
         if: startsWith(github.ref, 'refs/tags/')
@@ -187,5 +181,5 @@ jobs:
         id: attest
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          subject-digest: ${{ steps.manifest.outputs.digest }}
+          subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: true


### PR DESCRIPTION
Followed https://docs.docker.com/build/ci/github-actions/multi-platform/#distribute-build-across-multiple-runners to create a multi-platform build that supports both amd64 and arm64 architectures. Fixes #157.

This uses a matrix strategy to distribute the build for each platform across multiple runners and create manifest list using the [buildx imagetools create command](https://docs.docker.com/reference/cli/docker/buildx/imagetools/create/).

The following workflow will build the image for each platform on a dedicated runner using a matrix strategy and push by digest. Then, the merge job will create manifest lists and push them to Docker Hub. The [metadata action](https://github.com/docker/metadata-action) is used to set tags and labels. 


