### PR TITLE
fix: Handle HTTP timeouts gracefully during test execution

### DIFF
--- a/src/asqi/container_manager.py
+++ b/src/asqi/container_manager.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
 import yaml
+from requests import exceptions as requests_exceptions
 
 import docker
 from asqi.config import ContainerConfig
@@ -514,7 +515,13 @@ def run_container_with_args(
                         if line:  # Only process non-empty lines
                             output_lines.append(line)
                             container_logger.info(line)
-                except (UnicodeDecodeError, docker_errors.APIError) as e:
+                except (
+                    UnicodeDecodeError,
+                    docker_errors.APIError,
+                    requests_exceptions.Timeout,
+                    requests_exceptions.ReadTimeout,
+                    requests_exceptions.ConnectionError,
+                ) as e:
                     logger.warning(f"Failed to stream container logs: {e}")
 
             # Wait for completion
@@ -522,6 +529,7 @@ def run_container_with_args(
                 exit_status = container.wait(timeout=container_config.timeout_seconds)
                 result["exit_code"] = exit_status["StatusCode"]
             except docker_errors.APIError as api_error:
+                # Docker API error during wait; attempt to kill and report
                 try:
                     container.kill()
                 except (docker_errors.APIError, docker_errors.NotFound) as e:
@@ -530,6 +538,26 @@ def run_container_with_args(
                     f"Container execution failed with API error: {api_error}"
                 )
                 return result
+            except (
+                requests_exceptions.Timeout,
+                requests_exceptions.ReadTimeout,
+                requests_exceptions.ConnectionError,
+            ) as e:
+                # HTTP/socket timeout while waiting for the container to finish.
+                # Treat as container timeout, terminate container and report gracefully.
+                try:
+                    container.kill()
+                except (docker_errors.APIError, docker_errors.NotFound) as ke:
+                    logger.warning(
+                        f"Failed to kill container {getattr(container, 'id', '<unknown>')}: {ke}"
+                    )
+                # Use 137 (SIGKILL) to indicate timeout/forced termination
+                result["exit_code"] = 137
+                result["error"] = (
+                    f"Container execution timed out after {container_config.timeout_seconds}s for image '{image}': {e}"
+                )
+                # Fall through to collect any logs gathered so far and return
+                # Do not re-raise; ensure workflow can continue
 
             # Get output (use streamed output if available, otherwise get all logs)
             try:
@@ -540,7 +568,13 @@ def run_container_with_args(
                     result["output"] = container.logs().decode(
                         "utf-8", errors="replace"
                     )
-            except (UnicodeDecodeError, docker_errors.APIError) as e:
+            except (
+                UnicodeDecodeError,
+                docker_errors.APIError,
+                requests_exceptions.Timeout,
+                requests_exceptions.ReadTimeout,
+                requests_exceptions.ConnectionError,
+            ) as e:
                 result["output"] = "\n".join(output_lines) if output_lines else ""
                 logger.warning(f"Failed to retrieve container logs: {e}")
 
@@ -553,6 +587,19 @@ def run_container_with_args(
         except docker_errors.APIError as e:
             result["error"] = f"Docker API error running image '{image}': {e}"
         except TimeoutError as e:
+            # Built-in TimeoutError during container start
+            result["exit_code"] = 137
+            result["error"] = (
+                f"Container execution timed out after {container_config.timeout_seconds}s for image '{image}': {e}"
+            )
+        except (
+            requests_exceptions.Timeout,
+            requests_exceptions.ReadTimeout,
+            requests_exceptions.ConnectionError,
+        ) as e:
+            # Network/HTTP timeout or connection error to Docker daemon.
+            # Report gracefully without crashing the workflow.
+            result["exit_code"] = 137
             result["error"] = (
                 f"Container execution timed out after {container_config.timeout_seconds}s for image '{image}': {e}"
             )

--- a/src/asqi/workflow.py
+++ b/src/asqi/workflow.py
@@ -564,12 +564,30 @@ def run_test_suite_workflow(
                     test_plan["test_params"],
                     container_config,
                 )
-                test_handles.append(handle)
+                test_handles.append((handle, test_plan))
 
             # Collect results as they complete
             all_results = []
-            for handle in test_handles:
-                result = handle.get_result()
+            for handle, test_plan in test_handles:
+                try:
+                    result = handle.get_result()
+                except Exception as e:  # Gracefully handle DBOS/HTTP timeouts per test
+                    DBOS.logger.error(
+                        f"Test execution handle failed for {test_plan['test_name']} (image: {test_plan['image']}): {e}"
+                    )
+                    # Synthesize a failed TestExecutionResult with timeout semantics
+                    result = TestExecutionResult(
+                        test_plan["test_name"],
+                        test_plan["sut_name"],
+                        test_plan["image"],
+                    )
+                    now = time.time()
+                    result.start_time = now
+                    result.end_time = now
+                    result.exit_code = 137  # convention for forced termination/timeout
+                    result.success = False
+                    result.error_message = f"Test execution failed: {e}"
+                    result.container_output = ""
                 all_results.append(result)
                 try:
                     progress.advance(task)
@@ -595,13 +613,28 @@ def run_test_suite_workflow(
                 test_plan["test_params"],
                 container_config,
             )
-            test_handles.append(handle)
+            test_handles.append((handle, test_plan))
 
         # Collect results as they complete
         all_results = []
         progress_interval = max(1, test_count // executor_config["progress_interval"])
-        for i, handle in enumerate(test_handles, 1):
-            result = handle.get_result()
+        for i, (handle, test_plan) in enumerate(test_handles, 1):
+            try:
+                result = handle.get_result()
+            except Exception as e:
+                DBOS.logger.error(
+                    f"Test execution handle failed for {test_plan['test_name']} (image: {test_plan['image']}): {e}"
+                )
+                result = TestExecutionResult(
+                    test_plan["test_name"], test_plan["sut_name"], test_plan["image"]
+                )
+                now = time.time()
+                result.start_time = now
+                result.end_time = now
+                result.exit_code = 137
+                result.success = False
+                result.error_message = f"Test execution failed: {e}"
+                result.container_output = ""
             all_results.append(result)
             if i % progress_interval == 0 or i == test_count:
                 console.print(f"[dim]Completed {i}/{test_count} tests[/dim]")


### PR DESCRIPTION
This pull request improves the robustness of container execution and test workflow handling by adding comprehensive error handling for network and HTTP timeouts, especially those related to Docker daemon connectivity. It ensures that such failures are handled gracefully, preventing workflow crashes and providing clear error reporting and consistent exit codes.

**Container execution and error handling improvements:**

* Added handling for `requests` timeout and connection errors (such as `Timeout`, `ReadTimeout`, and `ConnectionError`) throughout the `run_container_with_args` function in `container_manager.py`, ensuring that network issues with the Docker daemon do not crash the workflow and are reported with a standardized exit code (137) and error message. [[1]](diffhunk://#diff-829b52e9e25efc720c5a5eeb4eaf852b85046a25183e61bf208fd9054eadcf86R11) [[2]](diffhunk://#diff-829b52e9e25efc720c5a5eeb4eaf852b85046a25183e61bf208fd9054eadcf86L517-R532) [[3]](diffhunk://#diff-829b52e9e25efc720c5a5eeb4eaf852b85046a25183e61bf208fd9054eadcf86R541-R560) [[4]](diffhunk://#diff-829b52e9e25efc720c5a5eeb4eaf852b85046a25183e61bf208fd9054eadcf86L543-R577) [[5]](diffhunk://#diff-829b52e9e25efc720c5a5eeb4eaf852b85046a25183e61bf208fd9054eadcf86R590-R602)

**Test workflow robustness:**

* Updated `run_test_suite_workflow` in `workflow.py` to catch exceptions from test execution handles, log the error, and synthesize a failed `TestExecutionResult` with timeout semantics (exit code 137 and a clear error message), ensuring that individual test failures due to infrastructure issues do not halt the entire test suite. [[1]](diffhunk://#diff-5467b80822ff3e22d65c0624e19e29876afe7bd60dfffd2bde335c16369842adL567-R590) [[2]](diffhunk://#diff-5467b80822ff3e22d65c0624e19e29876afe7bd60dfffd2bde335c16369842adL598-R637)