### PR TITLE
Use cache for test container docker builds

### DIFF
--- a/test_containers/chatbot_simulator/Dockerfile
+++ b/test_containers/chatbot_simulator/Dockerfile
@@ -4,11 +4,14 @@ FROM python:3.11-slim AS builder
 WORKDIR /app
 
 # Install build tools (only in builder)
-RUN apt-get update && apt-get install -y --no-install-recommends build-essential \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update && apt-get install -y --no-install-recommends build-essential \
     && rm -rf /var/lib/apt/lists/*
 
 # Install dependencies into a temporary /install directory
-RUN pip install --no-cache-dir --upgrade pip setuptools wheel \
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip install --no-cache-dir --upgrade pip setuptools wheel \
     && pip install --no-cache-dir --prefix=/install openevals==0.1.0 rich
 
 # Stage 2: Runtime (minimal, no build tools)

--- a/test_containers/deepteam/Dockerfile
+++ b/test_containers/deepteam/Dockerfile
@@ -1,9 +1,18 @@
 # Stage 1: Build dependencies
 FROM python:3.11-slim AS builder
 WORKDIR /app
-RUN apt-get update && \
+
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update && \
     apt-get install -y --no-install-recommends curl build-essential && \
-    curl https://sh.rustup.rs -sSf | sh -s -- -y && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN --mount=type=cache,target=/root/.cache \
+    curl https://sh.rustup.rs -sSf | sh -s -- -y
+
+RUN --mount=type=cache,target=/root/.cache/pip \
+    --mount=type=cache,target=/root/.cargo,sharing=locked \
     . "$HOME/.cargo/env" && \
     pip install --no-cache-dir --upgrade pip setuptools wheel && \
     pip install --no-cache-dir --prefix=/install deepteam==0.2.4 litellm==1.76.0

--- a/test_containers/deepteam/Dockerfile
+++ b/test_containers/deepteam/Dockerfile
@@ -13,7 +13,7 @@ RUN --mount=type=cache,target=/root/.cache \
     curl https://sh.rustup.rs -sSf | sh -s -- -y && \
     . "$HOME/.cargo/env" && \
     pip install --no-cache-dir --upgrade pip setuptools wheel && \
-    pip install --no-cache-dir --prefix=/install deepteam==0.2.4 litellm==1.76.0
+    pip install --no-cache-dir --prefix=/install deepteam==0.2.4 deepeval==3.3.9 litellm==1.76.0
 
 # Stage 2: Runtime (Python 3.11 slim)
 FROM python:3.11-slim

--- a/test_containers/deepteam/Dockerfile
+++ b/test_containers/deepteam/Dockerfile
@@ -9,10 +9,8 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     rm -rf /var/lib/apt/lists/*
 
 RUN --mount=type=cache,target=/root/.cache \
-    curl https://sh.rustup.rs -sSf | sh -s -- -y
-
-RUN --mount=type=cache,target=/root/.cache/pip \
     --mount=type=cache,target=/root/.cargo,sharing=locked \
+    curl https://sh.rustup.rs -sSf | sh -s -- -y && \
     . "$HOME/.cargo/env" && \
     pip install --no-cache-dir --upgrade pip setuptools wheel && \
     pip install --no-cache-dir --prefix=/install deepteam==0.2.4 litellm==1.76.0

--- a/test_containers/garak/Dockerfile
+++ b/test_containers/garak/Dockerfile
@@ -10,13 +10,12 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     rm -rf /var/lib/apt/lists/*
 
 RUN --mount=type=cache,target=/root/.cache \
+    --mount=type=cache,target=/root/.cache/pip \
     curl https://sh.rustup.rs -sSf | sh -s -- -y && \
-    . "$HOME/.cargo/env"
+    . "$HOME/.cargo/env" && \
+    pip install --no-cache-dir --user garak==0.12.0
 
 ENV PATH="/root/.cargo/bin:${PATH}"
-
-RUN --mount=type=cache,target=/root/.cache/pip \
-    pip install --no-cache-dir --user garak==0.12.0
 
 FROM python:3.11-slim
 

--- a/test_containers/garak/Dockerfile
+++ b/test_containers/garak/Dockerfile
@@ -3,15 +3,20 @@ FROM python:3.11-slim AS builder
 
 WORKDIR /app
 
-RUN apt-get update && \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update && \
     apt-get install -y --no-install-recommends curl build-essential && \
-    curl https://sh.rustup.rs -sSf | sh -s -- -y && \
-    . "$HOME/.cargo/env" && \
     rm -rf /var/lib/apt/lists/*
+
+RUN --mount=type=cache,target=/root/.cache \
+    curl https://sh.rustup.rs -sSf | sh -s -- -y && \
+    . "$HOME/.cargo/env"
 
 ENV PATH="/root/.cargo/bin:${PATH}"
 
-RUN pip install --no-cache-dir --user garak==0.12.0
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip install --no-cache-dir --user garak==0.12.0
 
 FROM python:3.11-slim
 

--- a/test_containers/trustllm/Dockerfile
+++ b/test_containers/trustllm/Dockerfile
@@ -2,14 +2,17 @@ FROM python:3.11-slim AS builder
 
 WORKDIR /tmp
 
-RUN apt-get update && \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update && \
     apt-get install -y --no-install-recommends \
     git \
     build-essential \
     unzip \
     && rm -rf /var/lib/apt/lists/*
 
-RUN git clone https://github.com/timlrx/TrustLLM.git && \
+RUN --mount=type=cache,target=/root/.cache/pip \
+    git clone https://github.com/timlrx/TrustLLM.git && \
     cd TrustLLM/trustllm_pkg && \
     pip install --no-cache-dir --user . && \
     cd /tmp/TrustLLM && \


### PR DESCRIPTION
Add build cache mounts for other test-containers as well to speed up build process.