### PR TITLE
Use uv, python 3.12 and debian-slim in test container build

### DIFF
--- a/test_containers/chatbot_simulator/Dockerfile
+++ b/test_containers/chatbot_simulator/Dockerfile
@@ -20,17 +20,16 @@ RUN uv python install 3.12
 # Create virtual environment and install dependencies
 RUN uv venv
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv pip install openevals==0.1.0 rich
+    uv pip install openevals==0.1.0 rich openai langchain-openai langchain-core pydantic
 
-# Stage 2: Runtime (minimal, no build tools)
-FROM python:3.12-slim
+# Stage 2: Runtime
+FROM debian:bookworm-slim
 
 WORKDIR /app
 
-# Copy virtual environment from builder
+# Copy venv, Python installation and set path
 COPY --from=builder /app/.venv /app/.venv
-
-# Add venv to PATH
+COPY --from=builder /python /python
 ENV PATH="/app/.venv/bin:$PATH"
 
 # Copy your app code

--- a/test_containers/chatbot_simulator/Dockerfile
+++ b/test_containers/chatbot_simulator/Dockerfile
@@ -1,26 +1,37 @@
 # Stage 1: Builder
-FROM python:3.11-slim AS builder
+FROM ghcr.io/astral-sh/uv:bookworm-slim AS builder
 
 WORKDIR /app
 
-# Install build tools (only in builder)
+# Install build tools
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \
     apt-get update && apt-get install -y --no-install-recommends build-essential \
     && rm -rf /var/lib/apt/lists/*
 
-# Install dependencies into a temporary /install directory
-RUN --mount=type=cache,target=/root/.cache/pip \
-    pip install --no-cache-dir --upgrade pip setuptools wheel \
-    && pip install --no-cache-dir --prefix=/install openevals==0.1.0 rich
+# Configure uv for faster builds
+ENV UV_COMPILE_BYTECODE=1 UV_LINK_MODE=copy
+ENV UV_PYTHON_INSTALL_DIR=/python
+ENV UV_PYTHON_PREFERENCE=only-managed
+
+# Install Python
+RUN uv python install 3.12
+
+# Create virtual environment and install dependencies
+RUN uv venv
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv pip install openevals==0.1.0 rich
 
 # Stage 2: Runtime (minimal, no build tools)
-FROM python:3.11-slim
+FROM python:3.12-slim
 
 WORKDIR /app
 
-# Copy just the built Python packages
-COPY --from=builder /install /usr/local
+# Copy virtual environment from builder
+COPY --from=builder /app/.venv /app/.venv
+
+# Add venv to PATH
+ENV PATH="/app/.venv/bin:$PATH"
 
 # Copy your app code
 COPY manifest.yaml .

--- a/test_containers/deepteam/Dockerfile
+++ b/test_containers/deepteam/Dockerfile
@@ -29,14 +29,13 @@ RUN --mount=type=cache,target=/root/.cache \
     rustup default stable && \
     uv pip install deepteam==0.2.4 deepeval==3.3.9 litellm==1.76.0
 
-# Stage 2: Runtime (Python 3.12 slim)
-FROM python:3.12-slim
+# Stage 2: Runtime
+FROM debian:bookworm-slim
 WORKDIR /app
 
-# Copy virtual environment from builder
+# Copy venv, Python installation and set path
 COPY --from=builder /app/.venv /app/.venv
-
-# Add venv to PATH
+COPY --from=builder /python /python
 ENV PATH="/app/.venv/bin:$PATH"
 COPY manifest.yaml .
 COPY entrypoint.py .

--- a/test_containers/deepteam/Dockerfile
+++ b/test_containers/deepteam/Dockerfile
@@ -1,24 +1,43 @@
 # Stage 1: Build dependencies
-FROM python:3.11-slim AS builder
+FROM ghcr.io/astral-sh/uv:bookworm-slim AS builder
 WORKDIR /app
 
+# Install build tools and Rust
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \
     apt-get update && \
-    apt-get install -y --no-install-recommends curl build-essential && \
+    apt-get install -y --no-install-recommends curl build-essential ca-certificates && \
     rm -rf /var/lib/apt/lists/*
 
+# Configure uv for faster builds
+ENV UV_COMPILE_BYTECODE=1 UV_LINK_MODE=copy
+ENV UV_PYTHON_INSTALL_DIR=/python
+ENV UV_PYTHON_PREFERENCE=only-managed
+
+# Install Python
+RUN uv python install 3.12
+
+# Create virtual environment
+RUN uv venv
+
+# Install Rust and Python packages in one step
 RUN --mount=type=cache,target=/root/.cache \
     --mount=type=cache,target=/root/.cargo,sharing=locked \
+    --mount=type=cache,target=/root/.cache/uv \
     curl https://sh.rustup.rs -sSf | sh -s -- -y && \
     . "$HOME/.cargo/env" && \
-    pip install --no-cache-dir --upgrade pip setuptools wheel && \
-    pip install --no-cache-dir --prefix=/install deepteam==0.2.4 deepeval==3.3.9 litellm==1.76.0
+    rustup default stable && \
+    uv pip install deepteam==0.2.4 deepeval==3.3.9 litellm==1.76.0
 
-# Stage 2: Runtime (Python 3.11 slim)
-FROM python:3.11-slim
+# Stage 2: Runtime (Python 3.12 slim)
+FROM python:3.12-slim
 WORKDIR /app
-COPY --from=builder /install /usr/local
+
+# Copy virtual environment from builder
+COPY --from=builder /app/.venv /app/.venv
+
+# Add venv to PATH
+ENV PATH="/app/.venv/bin:$PATH"
 COPY manifest.yaml .
 COPY entrypoint.py .
 

--- a/test_containers/garak/Dockerfile
+++ b/test_containers/garak/Dockerfile
@@ -1,29 +1,44 @@
 
-FROM python:3.11-slim AS builder
+FROM ghcr.io/astral-sh/uv:bookworm-slim AS builder
 
 WORKDIR /app
 
+# Install build tools and Rust
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \
     apt-get update && \
-    apt-get install -y --no-install-recommends curl build-essential && \
+    apt-get install -y --no-install-recommends curl build-essential ca-certificates && \
     rm -rf /var/lib/apt/lists/*
 
+# Configure uv for faster builds
+ENV UV_COMPILE_BYTECODE=1 UV_LINK_MODE=copy
+ENV UV_PYTHON_INSTALL_DIR=/python
+ENV UV_PYTHON_PREFERENCE=only-managed
+
+# Install Python
+RUN uv python install 3.12
+
+# Create virtual environment
+RUN uv venv
+
+# Install Rust and garak in one step
 RUN --mount=type=cache,target=/root/.cache \
-    --mount=type=cache,target=/root/.cache/pip \
+    --mount=type=cache,target=/root/.cargo,sharing=locked \
+    --mount=type=cache,target=/root/.cache/uv \
     curl https://sh.rustup.rs -sSf | sh -s -- -y && \
     . "$HOME/.cargo/env" && \
-    pip install --no-cache-dir --user garak==0.12.0
+    rustup default stable && \
+    uv pip install garak==0.12.0
 
-ENV PATH="/root/.cargo/bin:${PATH}"
-
-FROM python:3.11-slim
+FROM python:3.12-slim
 
 WORKDIR /app
 
-COPY --from=builder /root/.local /root/.local
+# Copy virtual environment from builder
+COPY --from=builder /app/.venv /app/.venv
 
-ENV PATH="/root/.local/bin:${PATH}"
+# Add venv to PATH
+ENV PATH="/app/.venv/bin:$PATH"
 
 COPY manifest.yaml .
 COPY entrypoint.py .

--- a/test_containers/garak/Dockerfile
+++ b/test_containers/garak/Dockerfile
@@ -21,7 +21,7 @@ RUN uv python install 3.12
 # Create virtual environment
 RUN uv venv
 
-# Install Rust and garak in one step
+# Install Rust and garak
 RUN --mount=type=cache,target=/root/.cache \
     --mount=type=cache,target=/root/.cargo,sharing=locked \
     --mount=type=cache,target=/root/.cache/uv \
@@ -30,14 +30,13 @@ RUN --mount=type=cache,target=/root/.cache \
     rustup default stable && \
     uv pip install garak==0.12.0
 
-FROM python:3.12-slim
+FROM debian:bookworm-slim
 
 WORKDIR /app
 
-# Copy virtual environment from builder
+# Copy venv, Python installation and set path
 COPY --from=builder /app/.venv /app/.venv
-
-# Add venv to PATH
+COPY --from=builder /python /python
 ENV PATH="/app/.venv/bin:$PATH"
 
 COPY manifest.yaml .

--- a/test_containers/inspect_evals/Dockerfile
+++ b/test_containers/inspect_evals/Dockerfile
@@ -38,7 +38,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     uv add google-genai
 
 # Stage 2: Runtime
-FROM python:3.11-slim
+FROM debian:bookworm-slim
 
 WORKDIR /app
 
@@ -53,11 +53,11 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     sh get-docker.sh && \
     rm get-docker.sh
 
-# Copy installed packages and venv from builder
-COPY --from=builder /root/.local /root/.local
+# Copy venv, Python installation and set path
+COPY --from=builder /app/inspect_evals/.venv /app/.venv
+COPY --from=builder /python /python
+ENV PATH="/app/.venv/bin:$PATH"
 COPY --from=builder /app/inspect_evals /app/inspect_evals
-
-ENV PATH="/app/inspect_evals/.venv/bin:/root/.local/bin:$PATH"
 
 # Set environment variables
 ENV HF_DATASETS_TRUST_REMOTE_CODE=1

--- a/test_containers/inspect_evals/Dockerfile
+++ b/test_containers/inspect_evals/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Builder
-FROM python:3.11-slim AS builder
+FROM ghcr.io/astral-sh/uv:bookworm-slim AS builder
 
 WORKDIR /app
 
@@ -9,12 +9,16 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     apt-get update && apt-get install -y \
     git \
     curl \
+    ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
-# Install uv with cache mount for faster repeated builds
-RUN --mount=type=cache,target=/root/.cache \
-    curl -LsSf https://astral.sh/uv/install.sh | sh
-ENV PATH="/root/.local/bin:$PATH"
+# Configure uv for faster builds
+ENV UV_COMPILE_BYTECODE=1 UV_LINK_MODE=copy
+ENV UV_PYTHON_INSTALL_DIR=/python
+ENV UV_PYTHON_PREFERENCE=only-managed
+
+# Install Python
+RUN uv python install 3.11
 
 # Set environment variable to allow remote code execution for datasets
 ENV HF_DATASETS_TRUST_REMOTE_CODE=1
@@ -28,9 +32,8 @@ RUN git clone https://github.com/UKGovernmentBEIS/inspect_evals.git && \
 RUN cd inspect_evals && uv venv
 
 RUN --mount=type=cache,target=/root/.cache/uv \
-    --mount=type=cache,target=/root/.cache/pip \
     cd inspect_evals && \
-    uv sync --all-extras && \
+    uv sync --extra test --extra math --extra mle_bench --extra worldsense --extra scicode --extra ifeval --extra personality --extra stealth --extra bbq && \
     uv add tf-keras && \
     uv add google-genai
 

--- a/test_containers/mock_tester/Dockerfile
+++ b/test_containers/mock_tester/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM python:3.12-slim
 
 WORKDIR /app
 

--- a/test_containers/trustllm/Dockerfile
+++ b/test_containers/trustllm/Dockerfile
@@ -36,16 +36,15 @@ RUN --mount=type=cache,target=/root/.cache/uv \
         mkdir -p /tmp/dataset/dataset; \
     fi
 
-FROM python:3.12-slim
+FROM debian:bookworm-slim
 
 WORKDIR /app
 
-# Copy virtual environment from builder
+# Copy venv, Python installation and set path
 COPY --from=builder /tmp/.venv /app/.venv
-COPY --from=builder /tmp/dataset /app/dataset
-
-# Add venv to PATH
+COPY --from=builder /python /python
 ENV PATH="/app/.venv/bin:$PATH"
+COPY --from=builder /tmp/dataset /app/dataset
 
 RUN python -c "\
 import os; \

--- a/test_containers/trustllm/Dockerfile
+++ b/test_containers/trustllm/Dockerfile
@@ -1,7 +1,8 @@
-FROM python:3.11-slim AS builder
+FROM ghcr.io/astral-sh/uv:bookworm-slim AS builder
 
 WORKDIR /tmp
 
+# Install system dependencies
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \
     apt-get update && \
@@ -9,12 +10,25 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     git \
     build-essential \
     unzip \
+    ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
-RUN --mount=type=cache,target=/root/.cache/pip \
+# Configure uv for faster builds
+ENV UV_COMPILE_BYTECODE=1 UV_LINK_MODE=copy
+ENV UV_PYTHON_INSTALL_DIR=/python
+ENV UV_PYTHON_PREFERENCE=only-managed
+
+# Install Python
+RUN uv python install 3.12
+
+# Create virtual environment
+RUN uv venv
+
+# Clone and install TrustLLM using uv
+RUN --mount=type=cache,target=/root/.cache/uv \
     git clone https://github.com/timlrx/TrustLLM.git && \
     cd TrustLLM/trustllm_pkg && \
-    pip install --no-cache-dir --user . && \
+    uv pip install . && \
     cd /tmp/TrustLLM && \
     if [ -f "dataset/dataset.zip" ]; then \
         unzip dataset/dataset.zip -d /tmp/dataset/; \
@@ -22,14 +36,16 @@ RUN --mount=type=cache,target=/root/.cache/pip \
         mkdir -p /tmp/dataset/dataset; \
     fi
 
-FROM python:3.11-slim
+FROM python:3.12-slim
 
 WORKDIR /app
 
-COPY --from=builder /root/.local /root/.local
+# Copy virtual environment from builder
+COPY --from=builder /tmp/.venv /app/.venv
 COPY --from=builder /tmp/dataset /app/dataset
 
-ENV PATH=/root/.local/bin:$PATH
+# Add venv to PATH
+ENV PATH="/app/.venv/bin:$PATH"
 
 RUN python -c "\
 import os; \


### PR DESCRIPTION
Testing out a build with uv and python 3.12. Python 3.12 will make development more consistent with the main asqi package and uv should speed up the python installs.

Unfortunately, some of the packages in inspect-ai do not work with Python 3.12, so we still have to use 3.11. I have also specified the extra dependencies to exclude docs and build tools.

Also, switched python-slim to debian-slim for the runtime build for a much smaller image