### PR TITLE
Fix/180 missing dotenv dependency

### DIFF
--- a/.github/workflows/asqi-cd.yaml
+++ b/.github/workflows/asqi-cd.yaml
@@ -62,6 +62,18 @@ jobs:
       - name: 🔨 Build package
         run: uv build --wheel
 
+      - name: 🧪 Test wheel
+        run: |
+          # Create isolated environment to test the wheel
+          python -m venv /tmp/test-wheel-env
+          source /tmp/test-wheel-env/bin/activate
+          pip install dist/*.whl
+          # Basic test
+          asqi --help
+          # Cleanup
+          deactivate
+          rm -rf /tmp/test-wheel-env
+
       - name: 🚀 Publish to PyPI
         # This action uses OIDC to securely authenticate with PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/asqi-cd.yaml
+++ b/.github/workflows/asqi-cd.yaml
@@ -66,8 +66,9 @@ jobs:
         run: |
           uv venv /tmp/test-wheel-env --python ${{ matrix.python-version }}
           source /tmp/test-wheel-env/bin/activate
-          uv add dist/*.whl
-          uv run asqi --help
+          # pip install forces use of temp environment
+          uv pip install dist/*.whl
+          asqi --help
           deactivate
           rm -rf /tmp/test-wheel-env
 

--- a/.github/workflows/asqi-cd.yaml
+++ b/.github/workflows/asqi-cd.yaml
@@ -62,15 +62,12 @@ jobs:
       - name: 🔨 Build package
         run: uv build --wheel
 
-      - name: 🧪 Test wheel
+      - name: 🧪 Test wheel installation
         run: |
-          # Create isolated environment to test the wheel
-          python -m venv /tmp/test-wheel-env
+          uv venv /tmp/test-wheel-env --python ${{ matrix.python-version }}
           source /tmp/test-wheel-env/bin/activate
-          pip install dist/*.whl
-          # Basic test
-          asqi --help
-          # Cleanup
+          uv add dist/*.whl
+          uv run asqi --help
           deactivate
           rm -rf /tmp/test-wheel-env
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
     "dbos>=1.12.0",
     "docker>=7.1.0",
     "pydantic>=2.11.7",
+    "python-dotenv>=1.1.1",
     "pyyaml>=6.0.2",
     "rich>=14.1.0",
     "typer>=0.16.0",


### PR DESCRIPTION
Fix #180. 
Add dependency. 
Tested locally built wheel. 
Add workflow action to test built wheel (tested locally - please help verify in Github)