### PR TITLE
Add init-config templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,19 @@ asqi execute-tests -t config/suites/demo_test.yaml -s config/systems/demo_system
 
 This short flow should download a demo test container and generate the test results in `output.json`. Now, to actually test your AI system, configure the `.env` file and try out the other test packages in: https://www.asqi.ai/quickstart.html
 
+### Generate Starter Config Templates
+
+Kick off new projects quickly with the built-in template generator:
+
+```bash
+# Create skeleton configs tailored to your needs
+asqi init-config --type systems --output my_systems.yaml
+asqi init-config --type suite --output my_suite.yaml --manifest-path test_containers/mock_tester
+asqi init-config --type score-card --output my_score_card.yaml
+```
+
+Pass `--manifest-path` (pointing to a `manifest.yaml` file or its directory) to pre-fill suite and systems templates with the right system roles and parameter placeholders.
+
 
 ## Documentation
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -31,6 +31,18 @@ asqi execute-tests -t config/suites/demo_test.yaml -s config/systems/demo_system
 
 This short flow should download a demo test container and generate the test results in `output.json`.
 
+### Generate Starter Config Templates
+
+Use the `init-config` command to scaffold new configuration files:
+
+```bash
+asqi init-config --type systems --output my_systems.yaml
+asqi init-config --type suite --output my_suite.yaml --manifest-path test_containers/mock_tester
+asqi init-config --type score-card --output my_score_card.yaml
+```
+
+When you pass `--manifest-path`, ASQI Engineer inspects the container manifest to pre-fill system roles, parameter placeholders, and optional dependencies.
+
 ## Getting Started with AI System Testing
 
 To configure the AI systems you want to test:

--- a/src/asqi/config_templates.py
+++ b/src/asqi/config_templates.py
@@ -1,0 +1,272 @@
+"""
+Utilities for generating starter configuration templates for ASQI Engineer.
+
+This module keeps template generation logic separate from the CLI so it can
+be tested in isolation. Templates can be generated from scratch or enriched
+with metadata from a container manifest to give users a head start when
+configuring test suites for specific packages.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from asqi.schemas import InputParameter, Manifest, SystemInput
+
+
+class TemplateType(str, Enum):
+    """Supported template types for the init-config command."""
+
+    SYSTEMS = "systems"
+    SUITE = "suite"
+    SCORE_CARD = "score-card"
+
+    @classmethod
+    def from_str(cls, value: str) -> "TemplateType":
+        """Case-insensitive lookup helper."""
+        value_lower = value.lower()
+        for member in cls:
+            if member.value == value_lower:
+                return member
+        raise ValueError(f"Unsupported template type '{value}'.")
+
+
+@dataclass
+class TemplateResult:
+    """Structured response for template generation."""
+
+    header_lines: List[str]
+    payload: Dict[str, Any]
+    optional_systems: List[str]
+
+
+_DEFAULT_LLM_PARAMS = {
+    "base_url": "http://localhost:4000/v1",
+    "model": "openai/gpt-4o-mini",
+    "api_key": "${OPENAI_API_KEY}",
+    "env_file": ".env",
+}
+
+
+def _default_params_for_system(system_type: str) -> Dict[str, Any]:
+    """Return sensible defaults for well-known system types."""
+    if system_type == "llm_api":
+        return dict(_DEFAULT_LLM_PARAMS)
+
+    # Fallback stub for unknown system types
+    return {"example_param": "value"}
+
+
+def _default_value_for_param(param: InputParameter) -> Any:
+    """Provide a starter value based on manifest parameter type."""
+    mapping = {
+        "string": "update-me",
+        "integer": 1,
+        "float": 0.0,
+        "boolean": False,
+        "list": [],
+        "object": {},
+    }
+    return mapping.get(param.type, "update-me")
+
+
+def _generate_systems_template(manifest: Optional[Manifest]) -> TemplateResult:
+    """Build a systems.yaml template."""
+    header = [
+        "# Starter systems configuration",
+        "# Update with your real endpoints and credentials.",
+    ]
+
+    systems: Dict[str, Any] = {}
+    optional_systems: List[str] = []
+
+    if manifest:
+        for system_input in manifest.input_systems:
+            params = _default_params_for_system(system_input.type)
+            systems[system_input.name] = {
+                "type": system_input.type,
+                "params": params,
+            }
+            if not system_input.required:
+                optional_systems.append(system_input.name)
+    else:
+        systems["my_llm_system"] = {
+            "type": "llm_api",
+            "params": _default_params_for_system("llm_api"),
+        }
+
+    return TemplateResult(
+        header_lines=header,
+        payload={"systems": systems},
+        optional_systems=optional_systems,
+    )
+
+
+def _build_system_mappings(system_inputs: List[SystemInput]) -> Dict[str, str]:
+    """Create `systems` mapping entries for non-SUT roles."""
+    mappings: Dict[str, str] = {}
+    for system_input in system_inputs:
+        if system_input.name == "system_under_test":
+            # systems_under_test handles these
+            continue
+        mappings[system_input.name] = system_input.name
+    return mappings
+
+
+def _generate_suite_template(
+    manifest: Optional[Manifest], image: Optional[str]
+) -> TemplateResult:
+    """Build a suite YAML template."""
+    header = [
+        "# Starter suite configuration",
+        "# Point image references to the container you want to execute.",
+    ]
+
+    if manifest:
+        header.append(f"# Generated with manifest: {manifest.name} v{manifest.version}")
+
+    default_image = image or (
+        f"{manifest.name}:{manifest.version}"
+        if manifest
+        else "my-registry/test-package:latest"
+    )
+
+    systems_under_test: List[str]
+    additional_systems: Dict[str, str] = {}
+    optional_systems: List[str] = []
+
+    if manifest and manifest.input_systems:
+        sut_inputs = [
+            s for s in manifest.input_systems if s.name == "system_under_test"
+        ]
+
+        if sut_inputs:
+            systems_under_test = [sut_inputs[0].name]
+        else:
+            # Fallback to the first required system if available
+            required_inputs = [s for s in manifest.input_systems if s.required]
+            systems_under_test = (
+                [required_inputs[0].name]
+                if required_inputs
+                else [manifest.input_systems[0].name]
+            )
+
+        additional_systems = _build_system_mappings(manifest.input_systems)
+        optional_systems = [
+            system_input.name
+            for system_input in manifest.input_systems
+            if not system_input.required
+        ]
+
+        params_block = {
+            param.name: _default_value_for_param(param)
+            for param in manifest.input_schema
+        }
+    else:
+        systems_under_test = ["my_llm_system"]
+        params_block = {"generations": 1}
+
+    test_definition: Dict[str, Any] = {
+        "name": "example_test",
+        "image": default_image,
+        "systems_under_test": systems_under_test,
+    }
+
+    if additional_systems:
+        # Only include keys not already listed as systems_under_test
+        filtered_mappings = {
+            role: name
+            for role, name in additional_systems.items()
+            if name not in systems_under_test
+        }
+        if filtered_mappings:
+            test_definition["systems"] = filtered_mappings
+
+    if params_block:
+        test_definition["params"] = params_block
+
+    suite_payload = {
+        "suite_name": "My Test Suite",
+        "test_suite": [test_definition],
+    }
+
+    return TemplateResult(
+        header_lines=header,
+        payload=suite_payload,
+        optional_systems=optional_systems,
+    )
+
+
+def _generate_score_card_template() -> TemplateResult:
+    """Build a score card YAML template."""
+    header = [
+        "# Starter score card configuration",
+        "# Update metric paths and thresholds to match your test outputs.",
+    ]
+
+    payload = {
+        "score_card_name": "My Score Card",
+        "indicators": [
+            {
+                "name": "Overall Quality",
+                "apply_to": {
+                    "test_name": "example_test",
+                },
+                "metric": "metrics.overall_score",
+                "assessment": [
+                    {
+                        "outcome": "PASS",
+                        "condition": "greater_equal",
+                        "threshold": 0.8,
+                        "description": "Score is at or above the target threshold.",
+                    },
+                    {
+                        "outcome": "FAIL",
+                        "condition": "less_than",
+                        "threshold": 0.8,
+                        "description": "Score fell below the required threshold.",
+                    },
+                ],
+            }
+        ],
+    }
+
+    return TemplateResult(header_lines=header, payload=payload, optional_systems=[])
+
+
+def generate_template(
+    template_type: TemplateType,
+    *,
+    manifest: Optional[Manifest] = None,
+    image: Optional[str] = None,
+) -> TemplateResult:
+    """Generate a template for the requested configuration type."""
+    if template_type is TemplateType.SYSTEMS:
+        return _generate_systems_template(manifest)
+    if template_type is TemplateType.SUITE:
+        return _generate_suite_template(manifest, image)
+    if template_type is TemplateType.SCORE_CARD:
+        return _generate_score_card_template()
+
+    raise ValueError(f"Unsupported template type '{template_type}'.")
+
+
+def resolve_manifest_path(path: Path) -> Path:
+    """
+    Resolve a manifest path that might point to either a manifest file or a directory.
+
+    Raises:
+        FileNotFoundError: if the manifest file cannot be located.
+    """
+    if path.is_file():
+        return path
+    if path.is_dir():
+        candidate = path / "manifest.yaml"
+        if candidate.is_file():
+            return candidate
+    raise FileNotFoundError(
+        f"Could not locate manifest.yaml at '{path}'. Provide a file path or directory containing manifest.yaml."
+    )

--- a/src/asqi/main.py
+++ b/src/asqi/main.py
@@ -2,6 +2,7 @@ import atexit
 import glob
 import os
 import signal
+from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 import typer
@@ -15,6 +16,11 @@ from asqi.config import (
     ExecutorConfig,
     interpolate_env_vars,
     merge_defaults_into_suite,
+)
+from asqi.config_templates import (
+    TemplateType,
+    generate_template,
+    resolve_manifest_path,
 )
 from asqi.container_manager import shutdown_containers
 from asqi.logging_config import configure_logging
@@ -181,6 +187,113 @@ def _handle_shutdown(signum=None, frame=None):
     console.print(
         "[yellow] Containers stopped. Waiting for workflows to complete...[/yellow]"
     )
+
+
+@app.command("init-config", help="Generate starter templates for configuration files.")
+def init_config_command(
+    config_type_value: str = typer.Option(
+        ...,
+        "--type",
+        "-t",
+        help="Type of configuration to generate: systems, suite, or score-card.",
+    ),
+    output_path: Path = typer.Option(
+        ...,
+        "--output",
+        "-o",
+        help="Path to write the generated template YAML file.",
+    ),
+    manifest_path: Optional[Path] = typer.Option(
+        None,
+        "--manifest-path",
+        "--manifest",
+        "-m",
+        help="Optional path to a manifest.yaml file (or its directory) to tailor the template.",
+    ),
+    image: Optional[str] = typer.Option(
+        None,
+        "--image",
+        "-i",
+        help="Image reference to use in the generated suite template. Defaults to manifest name/version when provided.",
+    ),
+    force: bool = typer.Option(
+        False,
+        "--force",
+        "-f",
+        help="Overwrite the output file if it already exists.",
+    ),
+):
+    """Generate starter configuration files for new users."""
+    target_path = output_path.expanduser()
+
+    if target_path.exists() and not force:
+        console.print(
+            f"[red]❌ Output file '{target_path}' already exists. Use --force to overwrite.[/red]"
+        )
+        raise typer.Exit(1)
+
+    try:
+        config_type = TemplateType.from_str(config_type_value)
+    except ValueError as e:
+        console.print(f"[red]❌ {e}[/red]")
+        raise typer.Exit(1)
+
+    manifest: Optional[Manifest] = None
+    if manifest_path:
+        try:
+            resolved_manifest = resolve_manifest_path(manifest_path.expanduser())
+            manifest_data = load_yaml_file(str(resolved_manifest))
+            manifest = Manifest(**manifest_data)
+        except (FileNotFoundError, ValueError, ValidationError, PermissionError) as e:
+            console.print(f"[red]❌ Failed to load manifest: {e}[/red]")
+            raise typer.Exit(1)
+
+    if manifest and config_type is TemplateType.SCORE_CARD:
+        console.print(
+            "[yellow]⚠️ Manifest input is not used when generating score card templates.[/yellow]"
+        )
+        manifest = None
+
+    if image and config_type is not TemplateType.SUITE:
+        console.print(
+            "[yellow]⚠️ Ignoring --image option because it only applies to suite templates.[/yellow]"
+        )
+        image = None
+
+    try:
+        template = generate_template(
+            config_type,
+            manifest=manifest,
+            image=image,
+        )
+    except ValueError as e:
+        console.print(f"[red]❌ {e}[/red]")
+        raise typer.Exit(1)
+
+    yaml_block = yaml.safe_dump(template.payload, sort_keys=False)
+    if template.header_lines:
+        header = "\n".join(template.header_lines)
+        file_contents = f"{header}\n\n{yaml_block}"
+    else:
+        file_contents = yaml_block
+
+    target_path.parent.mkdir(parents=True, exist_ok=True)
+    target_path.write_text(file_contents)
+
+    console.print(
+        f"[green]✨ Created {config_type.value} template at '{target_path}'.[/green]"
+    )
+
+    if manifest_path and manifest:
+        console.print(
+            f"[blue]📄 Based on manifest: {manifest.name} v{manifest.version}[/blue]"
+        )
+
+    if template.optional_systems:
+        optional_roles = ", ".join(template.optional_systems)
+        console.print(
+            f"[yellow]Note: The following system roles are optional and can be removed if not needed: {optional_roles}[/yellow]"
+        )
 
 
 @app.command("validate", help="Validate test plan configuration without execution.")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,134 @@
 import os
+import sys
+import types
+from types import SimpleNamespace
+
+
+def _install_docker_stub():
+    """Provide a lightweight docker module stub for tests."""
+    if "docker" in sys.modules:
+        return
+
+    docker_stub = types.ModuleType("docker")
+    errors_stub = types.ModuleType("docker.errors")
+    types_stub = types.ModuleType("docker.types")
+
+    class APIError(Exception):
+        pass
+
+    class ImageNotFound(Exception):
+        pass
+
+    class NotFound(ImageNotFound):
+        pass
+
+    class ContainerError(Exception):
+        def __init__(self, container, exit_status, command, image, stderr):
+            super().__init__(stderr)
+            self.container = container
+            self.exit_status = exit_status
+            self.command = command
+            self.image = image
+            self.stderr = stderr
+
+    errors_stub.APIError = APIError
+    errors_stub.ImageNotFound = ImageNotFound
+    errors_stub.NotFound = NotFound
+    errors_stub.ContainerError = ContainerError
+
+    class Mount:
+        def __init__(self, *args, **kwargs):
+            self.source = kwargs.get("source")
+            self.target = kwargs.get("target")
+
+    types_stub.Mount = Mount
+
+    def from_env():
+        client = SimpleNamespace(
+            images=SimpleNamespace(
+                get=lambda *args, **kwargs: SimpleNamespace(),
+                pull=lambda *args, **kwargs: None,
+                list=lambda: [],
+            ),
+            close=lambda: None,
+        )
+        return client
+
+    docker_stub.from_env = from_env
+    docker_stub.errors = errors_stub
+    docker_stub.types = types_stub
+
+    sys.modules["docker"] = docker_stub
+    sys.modules["docker.errors"] = errors_stub
+    sys.modules["docker.types"] = types_stub
+
+
+_install_docker_stub()
+
+
+def _install_dbos_stub():
+    """Provide a lightweight dbos module stub for tests."""
+    if "dbos" in sys.modules:
+        return
+
+    dbos_stub = types.ModuleType("dbos")
+
+    class _DBOS:
+        workflow_id = "test-workflow"
+        logger = SimpleNamespace(
+            info=lambda *args, **kwargs: None,
+            warning=lambda *args, **kwargs: None,
+            error=lambda *args, **kwargs: None,
+            debug=lambda *args, **kwargs: None,
+        )
+
+        def __init__(self, config=None):
+            self.config = config or {}
+
+        @staticmethod
+        def launch():
+            return None
+
+        @staticmethod
+        def start_workflow(*args, **kwargs):
+            return "workflow-stub"
+
+        @staticmethod
+        def step(*args, **kwargs):
+            def decorator(func):
+                return func
+
+            return decorator
+
+        @staticmethod
+        def workflow(*args, **kwargs):
+            def decorator(func):
+                return func
+
+            return decorator
+
+    class _DBOSConfig:
+        pass
+
+    class _Queue:
+        def __init__(self, name, concurrency=1):
+            self.name = name
+            self.concurrency = concurrency
+
+        def enqueue(self, *args, **kwargs):
+            return SimpleNamespace(
+                get_result=lambda: None,
+                get_workflow_id=lambda: "workflow-stub",
+            )
+
+    dbos_stub.DBOS = _DBOS
+    dbos_stub.DBOSConfig = _DBOSConfig
+    dbos_stub.Queue = _Queue
+
+    sys.modules["dbos"] = dbos_stub
+
+
+_install_dbos_stub()
 
 # Ensure the environment variable exists before importing modules under test
 os.environ.setdefault(

--- a/tests/test_config_templates.py
+++ b/tests/test_config_templates.py
@@ -1,0 +1,67 @@
+from asqi.config_templates import TemplateType, generate_template, resolve_manifest_path
+from asqi.schemas import InputParameter, Manifest, SystemInput
+
+
+def _build_sample_manifest() -> Manifest:
+    return Manifest(
+        name="mock_tester",
+        version="1.0.0",
+        description="A mock tester manifest",
+        input_systems=[
+            SystemInput(name="system_under_test", type="llm_api", required=True),
+            SystemInput(name="simulator_system", type="llm_api", required=False),
+        ],
+        input_schema=[
+            InputParameter(name="generations", type="integer", required=False),
+            InputParameter(name="temperature", type="float", required=False),
+        ],
+        output_metrics=[],
+        output_artifacts=None,
+    )
+
+
+def test_generate_systems_template_with_manifest():
+    manifest = _build_sample_manifest()
+    template = generate_template(TemplateType.SYSTEMS, manifest=manifest)
+
+    assert "system_under_test" in template.payload["systems"]
+    assert "simulator_system" in template.payload["systems"]
+
+    sut_entry = template.payload["systems"]["system_under_test"]
+    assert sut_entry["type"] == "llm_api"
+    assert template.optional_systems == ["simulator_system"]
+
+
+def test_generate_suite_template_uses_manifest_defaults():
+    manifest = _build_sample_manifest()
+    template = generate_template(
+        TemplateType.SUITE, manifest=manifest, image="registry/mock:latest"
+    )
+
+    test_definition = template.payload["test_suite"][0]
+    assert test_definition["image"] == "registry/mock:latest"
+    assert test_definition["systems_under_test"] == ["system_under_test"]
+    assert test_definition["systems"]["simulator_system"] == "simulator_system"
+    assert test_definition["params"]["generations"] == 1
+    assert test_definition["params"]["temperature"] == 0.0
+    assert template.optional_systems == ["simulator_system"]
+
+
+def test_generate_score_card_template_defaults():
+    template = generate_template(TemplateType.SCORE_CARD)
+
+    assert template.payload["score_card_name"] == "My Score Card"
+    indicator = template.payload["indicators"][0]
+    assert indicator["metric"] == "metrics.overall_score"
+
+
+def test_resolve_manifest_path_accepts_directory(tmp_path):
+    manifest_dir = tmp_path / "test_container"
+    manifest_dir.mkdir()
+    manifest_file = manifest_dir / "manifest.yaml"
+    manifest_file.write_text(
+        "name: example\nversion: 1.0\ninput_systems: []\ninput_schema: []\noutput_metrics: []\n"
+    )
+
+    resolved = resolve_manifest_path(manifest_dir)
+    assert resolved == manifest_file


### PR DESCRIPTION
## Summary
- add `asqi init-config` CLI command to scaffold systems, suite, and score card configs
- support manifest-aware scaffolding and document new flow
- add targeted tests and lightweight stubs so CLI coverage runs without Docker/DBOS

## Testing
- PYTHONPATH=src pytest tests/test_config_templates.py tests/test_main.py

Closes #195