### PR TITLE
Fix/217: fix broken pipy image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ASQI Engineer
 
-![ASQI Engineer](./docs/asqi-engineer-cover.png)
+![ASQI Engineer](https://raw.githubusercontent.com/asqi-engineer/asqi-engineer/main/docs/asqi-engineer-cover.png)
 
 ASQI (AI Solutions Quality Index) Engineer helps teams test and evaluate AI systems. It runs containerized test packages, automates scoring, and provides durable execution workflows.
 


### PR DESCRIPTION
CLOSES: https://github.com/asqi-engineer/asqi-engineer/issues/217

I added a direct raw file URL that points to the main branch (docs/asqi-engineer-cover.png). The link will always reference the latest image of that address on the main branch. You can see more here: [Viewing and understanding files - GitHub Enterprise Cloud Docs](https://docs.github.com/en/enterprise-cloud@latest/repositories/working-with-files/using-files/viewing-and-understanding-files#viewing-or-copying-the-raw-file-content)