### PR TITLE
Add `workflow_id` container label

### DIFF
--- a/src/asqi/container_manager.py
+++ b/src/asqi/container_manager.py
@@ -434,7 +434,7 @@ def run_container_with_args(
     container_config: ContainerConfig,
     environment: Optional[Dict[str, str]] = None,
     name: Optional[str] = None,
-    workflow_id: Optional[str] = None,
+    workflow_id: str = "",
 ) -> Dict[str, Any]:
     """
     Run a Docker container with specified arguments and return results.
@@ -445,7 +445,7 @@ def run_container_with_args(
         container_config: Container execution configurations
         environment: Optional dictionary of environment variables to pass to container
         name: Optional name for the container (will be used as container name in Docker)
-        workflow_id: Optional workflow identifier to uniquely associate the container with a workflow
+        workflow_id: Workflow identifier to uniquely associate the container with a workflow
 
     Returns:
         Dictionary with execution results including exit_code, output, success, etc.
@@ -473,7 +473,7 @@ def run_container_with_args(
             # Run container
             args, mounts = _extract_mounts_from_args(client, args)
             # Container labels
-            labels = {"workflow_id": workflow_id or "", "service": "asqi_engineer"}
+            labels = {"workflow_id": workflow_id, "service": "asqi_engineer"}
             logger.info(f"Running container for image '{image}' with args: {args}")
             if mounts:
                 logger.info(f"Mounts: {mounts}")

--- a/src/asqi/workflow.py
+++ b/src/asqi/workflow.py
@@ -336,7 +336,7 @@ def execute_single_test(
         environment=container_env,
         container_config=container_config,
         name=container_name,
-        workflow_id=DBOS.workflow_id,
+        workflow_id=DBOS.workflow_id or "",
     )
 
     result.end_time = time.time()

--- a/tests/test_container_manager.py
+++ b/tests/test_container_manager.py
@@ -519,6 +519,36 @@ class TestRunContainerWithArgs:
         call_kwargs = mock_client.containers.run.call_args[1]
         assert call_kwargs["mounts"] == test_mounts
 
+    def test_run_container_labels(self, mock_container_setup):
+        """Test that container labels are correctly applied."""
+        mock_client, _, mock_extract_mounts = mock_container_setup
+
+        container_config: ContainerConfig = ContainerConfig()
+        run_container_with_args(
+            image="test:latest",
+            args=["--test"],
+            container_config=container_config,
+            workflow_id="test_workflow",
+        )
+        mock_extract_mounts.assert_called_once()
+        call_kwargs = mock_client.containers.run.call_args[1]
+        assert call_kwargs["labels"] == {
+            "workflow_id": "test_workflow",
+            "service": "asqi_engineer",
+        }
+
+    def test_run_container_labels_empty_workflow(self, mock_container_setup):
+        """Test that container labels when workflow_id is empty"""
+        mock_client, _, mock_extract_mounts = mock_container_setup
+
+        container_config: ContainerConfig = ContainerConfig()
+        run_container_with_args(
+            image="test:latest", args=["--test"], container_config=container_config
+        )
+        mock_extract_mounts.assert_called_once()
+        call_kwargs = mock_client.containers.run.call_args[1]
+        assert call_kwargs["labels"] == {"workflow_id": "", "service": "asqi_engineer"}
+
     @pytest.mark.parametrize(
         "exception,expected_error_message",
         [


### PR DESCRIPTION
Closes: https://github.com/asqi-engineer/asqi-engineer/issues/225

Each container now has two labels to identify it uniquely, workflow_id and service

label:
- workflow_id: DBOS workflow id
- service: asqi_engineer

<img width="1287" height="47" alt="image" src="https://github.com/user-attachments/assets/b4e0400a-0047-4cb4-bf54-3f084b753786" />

Testing
---
docker ps -f "label=service=asqi_engineer"