### PR TITLE
Add input mount path to load hf dataset

### DIFF
--- a/sdg_containers/example_data_generator/entrypoint.py
+++ b/sdg_containers/example_data_generator/entrypoint.py
@@ -27,16 +27,18 @@ from asqi.datasets import load_hf_dataset
 from asqi.response_schemas import ContainerOutput, GeneratedDataset
 
 
-def load_input_dataset(dataset_config: Dict[str, Any], input_mount_path: Path) -> Dataset:
+def load_input_dataset(
+    dataset_config: Dict[str, Any], input_mount_path: Path
+) -> Dataset:
     """
     Load a HuggingFace dataset using ASQI's load_hf_dataset utility.
 
-    The dataset paths are already resolved by ASQI's workflow system before
-    being passed to the container, so no additional path resolution is needed.
+    The input_mount_path is passed to load_hf_dataset to resolve relative file paths
+    in the dataset config (e.g., data_files: "sample.json" becomes "/input/sample.json").
 
     Args:
-        dataset_config: Dataset configuration with loader_params (paths already resolved)
-        input_mount_path: Path to the input mount
+        dataset_config: Dataset configuration with loader_params
+        input_mount_path: Path to the input mount (typically /input)
 
     Returns:
         Loaded HuggingFace Dataset
@@ -217,7 +219,9 @@ def main():
         # Step 1: Load input dataset
         print("\n[1/3] Loading input dataset...")
         source_config = input_datasets["source_data"]
-        source_dataset = load_input_dataset(source_config, input_mount_path=input_mount_path)
+        source_dataset = load_input_dataset(
+            source_config, input_mount_path=input_mount_path
+        )
         print(f"Loaded {len(source_dataset)} samples from source_data")
 
         # Step 2: Generate augmented data

--- a/src/asqi/datasets.py
+++ b/src/asqi/datasets.py
@@ -6,12 +6,18 @@ from datasets import Dataset, load_dataset
 from asqi.schemas import HFDatasetDefinition
 
 
-def load_hf_dataset(dataset_config: Union[dict, HFDatasetDefinition], input_mount_path: Path | None = None) -> Dataset:
+def load_hf_dataset(
+    dataset_config: Union[dict, HFDatasetDefinition],
+    input_mount_path: Path | None = None,
+) -> Dataset:
     # TODO: consider using load_from_disk for caching purposes
     """Load a HuggingFace dataset using the provided loader parameters.
 
     Args:
         dataset_config: Configuration for loading the HuggingFace dataset.
+        input_mount_path: Optional path to prepend to relative data_files/data_dir paths.
+            Typically used in containers to resolve paths relative to the input mount point.
+            Absolute paths in the dataset config are not modified.
 
     Returns:
         Dataset: Loaded HuggingFace dataset.
@@ -40,14 +46,19 @@ def load_hf_dataset(dataset_config: Union[dict, HFDatasetDefinition], input_moun
     # 3. The "train" split is the default convention for single-split datasets in HuggingFace
     if input_mount_path:
         if loader_params.data_dir:
-            loader_params.data_dir = (input_mount_path / Path(loader_params.data_dir)).as_posix()
+            loader_params.data_dir = (
+                input_mount_path / Path(loader_params.data_dir)
+            ).as_posix()
         elif loader_params.data_files:
             if isinstance(loader_params.data_files, list):
                 loader_params.data_files = [
-                    (input_mount_path / Path(file)).as_posix() for file in loader_params.data_files
+                    (input_mount_path / Path(file)).as_posix()
+                    for file in loader_params.data_files
                 ]
             else:
-                loader_params.data_files = (input_mount_path / Path(loader_params.data_files)).as_posix()
+                loader_params.data_files = (
+                    input_mount_path / Path(loader_params.data_files)
+                ).as_posix()
     dataset = load_dataset(  # nosec B615
         path=loader_params.builder_name,
         data_dir=loader_params.data_dir,


### PR DESCRIPTION
Currently, using `load_hf_dataset` inside a container searches for the data files relative to the container WORKDIR, typically `/app`, instead of inside the input volume, typically at `/input`. This leads to an error when the files cannot be found. 

To simplify the process for the user, allow `load_hf_dataset` to accept an optional `input_mount_path` that it automatically adds as a prefix to any paths included in the `HFDatasetDefinition`. 

Tested with the example data generation container (which has also been updated to use this new feature). 