### PR TITLE
Support test scenarios as input datasets for chatbot simulator

### DIFF
--- a/config/datasets/demo_datasets.yaml
+++ b/config/datasets/demo_datasets.yaml
@@ -10,3 +10,14 @@ datasets:
     tags:
       - "example"
       - "reviews"
+
+  sample_chatbot_scenarios:
+    type: "huggingface"
+    description: "Sample chatbot test scenarios with questions and expected responses for customer service testing"
+    loader_params:
+      builder_name: "json"
+      data_files: "sample_chatbot_scenarios.json"
+    tags:
+      - "example"
+      - "chatbot"
+      - "qa"

--- a/test_containers/chatbot_simulator/Dockerfile
+++ b/test_containers/chatbot_simulator/Dockerfile
@@ -20,7 +20,7 @@ RUN uv python install 3.12
 # Create virtual environment and install dependencies
 RUN uv venv
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv pip install openevals==0.1.0 rich openai langchain-openai langchain-core pydantic jinja2
+    uv pip install openevals==0.1.0 rich openai langchain-openai langchain-core pydantic jinja2 asqi-engineer==0.4.1
 
 # Stage 2: Runtime
 FROM debian:bookworm-slim

--- a/test_containers/chatbot_simulator/manifest.yaml
+++ b/test_containers/chatbot_simulator/manifest.yaml
@@ -16,6 +16,19 @@ input_systems:
     required: false
     description: "LLM system for evaluating conversation quality"
 
+input_datasets:
+  - name: "test_scenarios"
+    type: "huggingface"
+    required: false
+    description: "Optional dataset of test scenarios with expected outputs. Each row should contain 'input' (user question/prompt) and 'expected_output' (expected chatbot response) columns."
+    features:
+      - name: "input"
+        dtype: "string"
+        description: "User question or prompt to test the chatbot with"
+      - name: "expected_output"
+        dtype: "string"
+        description: "Expected chatbot response or output for evaluation"
+
 input_schema:
   - name: "chatbot_purpose"
     type: "string"


### PR DESCRIPTION
Enhances the chatbot simulator by adding support for loading external test scenarios from datasets, making it easier to test chatbot responses against predefined inputs and expected outputs. 

**Dataset integration and configuration:**
- Added a new `sample_chatbot_scenarios` entry to `config/datasets/demo_datasets.yaml` for providing example chatbot test scenarios, including loader parameters and relevant tags.
- Updated `test_containers/chatbot_simulator/manifest.yaml` to define an optional `test_scenarios` dataset input, specifying required features (`input` and `expected_output`) for each row.

**Dependency and utility updates:**
- Modified `test_containers/chatbot_simulator/Dockerfile` to install the `asqi-engineer` package, which is required for dataset loading utilities.
- Imported the `load_hf_dataset` function from `asqi.datasets` in the simulator entrypoint to enable dataset loading.

**Scenario loading logic:**
- Implemented the `load_scenarios_from_dataset` function in `entrypoint.py` to load, validate, and format test scenarios from the provided dataset, ensuring required columns are present.
- Updated the chatbot simulation logic to prioritize loading scenarios from inline `custom_scenarios`, then from the input dataset, and finally from LLM generation if neither is provided.