### PR TITLE
fix: parse workflow error output

### DIFF
--- a/src/asqi/workflow.py
+++ b/src/asqi/workflow.py
@@ -576,11 +576,12 @@ def _execute_container_job(
 
         result.success = result.results.get("success", False)
     except ValueError as e:
-        # JSON parsing failed - use Docker error if available
-        if not result.error_message:
-            result.error_message = (
-                f"Failed to parse JSON output from item id '{item_id}': {e}"
-            )
+        # JSON parsing failed - combine with Docker error if present
+        parsing_error = f"Failed to parse JSON output from item id '{item_id}': {e}"
+        if result.error_message:
+            result.error_message = f"{result.error_message} | {parsing_error}"
+        else:
+            result.error_message = parsing_error
         result.success = False
         DBOS.logger.error(
             f"JSON parsing failed for item id {item_id}: {result.container_output[:200]}..."


### PR DESCRIPTION
This pull request improves error handling for container job execution by ensuring that errors reported in the container's JSON output are consistently extracted and surfaced. Additionally, it adds new tests to verify that both Docker-level and JSON-level errors are properly combined and reported.

Error handling improvements:

* Always attempts to parse the container's JSON output, regardless of the container's reported success, to extract any errors present in the JSON.
* If an error is found in the JSON output, it is added to the `error_message` field, and if there is also a Docker error, both errors are combined for clearer diagnostics.
* Ensures that if JSON parsing fails, the error message reflects this and includes the Docker error if available.

Testing improvements:

* Adds tests to verify that JSON errors are extracted and that Docker and JSON errors are combined in the `error_message` field.