### PR TITLE
Update docs for mapping

### DIFF
--- a/src/asqi/schemas.py
+++ b/src/asqi/schemas.py
@@ -771,7 +771,7 @@ class HFDatasetDefinition(BaseModel):
     )
     mapping: dict[str, str] = Field(
         default_factory=dict,
-        description="Optional mapping from manifest feature names to actual dataset column names.",
+        description="Optional mapping from existing dataset column names to their required names in manifest i.e. current_name: manifest_name.",
     )
     tags: list[str] = Field(
         default_factory=list,


### PR DESCRIPTION
The use of the mapping parameter follows HugginFace Dataset.rename_columns (https://huggingface.co/docs/datasets/v4.5.0/en/package_reference/main_classes#datasets.Dataset.rename_columns) which uses the current_name: new_name syntax. 

The use of this where used in asqi-engineer is correct. Only the docs need updating. 