### PR TITLE
cpu request default

### DIFF
--- a/docs/interface-spec.md
+++ b/docs/interface-spec.md
@@ -308,7 +308,7 @@ Pydantic `BaseModel` controlling Docker container execution.
 | Name | Type | Value |
 |---|---|---|
 | `MANIFEST_PATH` | `ClassVar[str]` | `"/app/manifest.yaml"` |
-| `DEFAULT_RUN_PARAMS` | `ClassVar[Dict[str, Any]]` | `{"detach": True, "remove": False, "network_mode": "host", "mem_limit": "2g", "cpu_period": 100000, "cpu_quota": 200000, "cap_drop": ["ALL"]}` |
+| `DEFAULT_RUN_PARAMS` | `ClassVar[Dict[str, Any]]` | `{"detach": True, "remove": False, "network_mode": "host", "mem_limit": "2g", "cpu_period": 100000, "cpu_quota": 200000, "cpu_request": "500m", "cap_drop": ["ALL"]}` |
 
 **Instance fields:**
 

--- a/src/asqi/config.py
+++ b/src/asqi/config.py
@@ -77,6 +77,7 @@ class ContainerConfig(BaseModel):
         "mem_limit": "2g",
         "cpu_period": 100000,
         "cpu_quota": 200000,
+        "cpu_request": "500m",
         "cap_drop": ["ALL"],
     }
 

--- a/tests/test_contract_config_helpers.py
+++ b/tests/test_contract_config_helpers.py
@@ -51,6 +51,7 @@ class TestContainerConfigContract:
             "mem_limit": "2g",
             "cpu_period": 100000,
             "cpu_quota": 200000,
+            "cpu_request": "500m",
             "cap_drop": ["ALL"],
         }
         assert ContainerConfig.DEFAULT_RUN_PARAMS == expected

--- a/tests/test_kubernetes_backend.py
+++ b/tests/test_kubernetes_backend.py
@@ -469,9 +469,18 @@ class TestBuildJobBody:
         body = _build_default_job_body()
         assert _workload(body)["resources"]["limits"]["cpu"] == "2"
 
-    def test_cpu_request_defaults_to_limit(self) -> None:
-        """Without cpu_request in run_params, the request equals the limit (Guaranteed QoS)."""
+    def test_cpu_request_default_is_500m(self) -> None:
+        """DEFAULT_RUN_PARAMS includes cpu_request="500m"."""
         body = _build_default_job_body()
+        resources = _workload(body)["resources"]
+        assert resources["requests"]["cpu"] == "500m"
+        assert resources["limits"]["cpu"] == "2"
+
+    def test_cpu_request_absent_defaults_to_limit(self) -> None:
+        """When cpu_request is absent from run_params, request falls back to limit (Guaranteed QoS)."""
+        config = ContainerConfig()
+        config.run_params.pop("cpu_request")
+        body = _build_default_job_body(config=config)
         resources = _workload(body)["resources"]
         assert resources["requests"]["cpu"] == resources["limits"]["cpu"]
 


### PR DESCRIPTION
## Summary

- `cpu_request: "500m"` was present in `docker_container.yaml` but missing from `DEFAULT_RUN_PARAMS` in `config.py`, so images that don't load the YAML file never passed a CPU request to the Kubernetes backend — causing request to equal the limit and blocking Burstable QoS scheduling.
- Adds the missing default directly in code so all code paths are covered.
- Updates affected tests and interface-spec documentation.

## Changes

- `src/asqi/config.py` — add `cpu_request: "500m"` to `DEFAULT_RUN_PARAMS`
- `tests/test_contract_config_helpers.py` — update expected dict to match new default
- `tests/test_kubernetes_backend.py` — split cpu_request test into default (500m) and explicit fallback (Guaranteed QoS) cases
- `docs/interface-spec.md` — update `DEFAULT_RUN_PARAMS` table entry
