### PR TITLE
Release v0.5.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,14 @@
 # Changelog
+## [0.5.7] - 2026-06-29
+
+### 🐛 Bug Fixes
+
+- Add cpu_request "500m" to DEFAULT_RUN_PARAMS (119fca4)
+
+### 📚 Documentation
+
+- Add cpu_request to DEFAULT_RUN_PARAMS in interface-spec (119fca4)
+
 ## [0.5.6] - 2026-06-26
 
 ### 🚀 Features

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "asqi-engineer"
-version = "0.5.6"
+version = "0.5.7"
 description = "ASQI quality checks for AI systems"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -175,7 +175,7 @@ wheels = [
 
 [[package]]
 name = "asqi-engineer"
-version = "0.5.6"
+version = "0.5.7"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
## Summary

Bumps the asqi engineer to **v0.5.7** (from v0.5.6) and cuts a stable release

## What's included

- CHANGELOG updated for v0.5.7

